### PR TITLE
feat: v1.2.0 — current electricity rate sensors (closes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ Up to **180 days of historical data** are backfilled on first install (from the 
 - Mercury bill corrections within the trailing 3 days are absorbed automatically (recent days are re-imported on every poll).
 - If you previously set up template-sensor + utility_meter workarounds for the Energy Dashboard, you can remove them after enabling these statistics.
 
+## 📊 Using with `dynamic_energy_cost` (per-appliance cost tracking)
+
+Five new sensors are exposed for the current electricity plan:
+
+| Entity                                     | Unit       | Notes                                               |
+| ------------------------------------------ | ---------- | --------------------------------------------------- |
+| `sensor.mercury_nz_current_rate`           | `NZD/kWh`  | Current per-kWh price (NZD, not cents)              |
+| `sensor.mercury_nz_daily_fixed_charge`     | `NZD/day`  | Daily fixed charge from the active plan             |
+| `sensor.mercury_nz_current_plan`           | text       | Plan name (e.g. "Anytime", "Low User")              |
+| `sensor.mercury_nz_icp_number`             | text       | ICP / Installation Control Point identifier         |
+| `sensor.mercury_nz_plan_change_pending`    | `yes`/`no` | Surfaces upcoming plan transitions                  |
+
+To wire `sensor.mercury_nz_current_rate` into the [HACS dynamic_energy_cost](https://github.com/martinarva/dynamic_energy_cost) integration:
+
+1. Install `dynamic_energy_cost` from HACS.
+2. Add the integration. For each appliance you want to track:
+   - **Power sensor**: a kWh-emitting entity (e.g. a Tapo P110M smart plug's `..._energy_kwh` entity).
+   - **Price sensor**: `sensor.mercury_nz_current_rate`.
+3. The resulting cost sensor reads `power × current_rate` and labels the output in `hass.config.currency`. Set `currency: NZD` in `configuration.yaml` under `homeassistant:` if you want the labels to read NZD.
+
+**Note**: Mercury's API stores rates in NZ cents; this integration converts to NZD/kWh internally so dynamic_energy_cost computes correct values out of the box. Time-of-use (TOU) plans are not yet supported — only the "Anytime" rate is exposed in this release.
+
 ## 🚀 Installation
 
 ### Option 1: HACS (Recommended)

--- a/custom_components/mercury_co_nz/const.py
+++ b/custom_components/mercury_co_nz/const.py
@@ -272,6 +272,46 @@ SENSOR_TYPES = {
         "device_class": None,
         "state_class": None,
     },
+    # Electricity plan / current rate (issue #6) — feeds HACS dynamic_energy_cost
+    # device_class deliberately None: HA's monetary class only allows state_class=total,
+    # but a current rate is semantically a measurement. Tibber's price sensor follows
+    # the same pattern. The unit "NZD/kWh" is the form dynamic_energy_cost parses
+    # correctly (it extracts only the /kWh denominator).
+    "plan_anytime_rate": {
+        "name": "Current Rate",
+        "unit": "NZD/kWh",
+        "icon": "mdi:cash-multiple",
+        "device_class": None,
+        "state_class": "measurement",
+    },
+    "plan_daily_fixed_charge": {
+        "name": "Daily Fixed Charge",
+        "unit": "NZD/day",
+        "icon": "mdi:cash-clock",
+        "device_class": None,
+        "state_class": "measurement",
+    },
+    "plan_current_plan_name": {
+        "name": "Current Plan",
+        "unit": None,
+        "icon": "mdi:format-list-bulleted-type",
+        "device_class": None,
+        "state_class": None,
+    },
+    "plan_icp_number": {
+        "name": "ICP Number",
+        "unit": None,
+        "icon": "mdi:identifier",
+        "device_class": None,
+        "state_class": None,
+    },
+    "plan_is_pending_plan_change": {
+        "name": "Plan Change Pending",
+        "unit": None,
+        "icon": "mdi:swap-horizontal",
+        "device_class": None,
+        "state_class": None,
+    },
 }
 
 # API Constants

--- a/custom_components/mercury_co_nz/coordinator.py
+++ b/custom_components/mercury_co_nz/coordinator.py
@@ -86,6 +86,14 @@ class MercuryDataUpdateCoordinator(DataUpdateCoordinator):
             usage_content_data = await self.api.get_usage_content()
             _LOGGER.info("Mercury coordinator: Received usage content data")
 
+            _LOGGER.info("📋 Fetching electricity plans data...")
+            plans_data = await self.api.get_electricity_plans()
+            _LOGGER.info("Mercury coordinator: Received plans data")
+            if plans_data:
+                _LOGGER.info("✅ Plans data contains %d keys: %s", len(plans_data), list(plans_data.keys()))
+            else:
+                _LOGGER.warning("⚠️ No plans data received")
+
             # Combine all datasets
             combined_data = usage_data.copy() if usage_data else {}
             if bill_data:
@@ -107,6 +115,11 @@ class MercuryDataUpdateCoordinator(DataUpdateCoordinator):
                 # Add usage content data with prefix to avoid naming conflicts
                 for key, value in usage_content_data.items():
                     combined_data[f"content_{key}"] = value
+
+            if plans_data:
+                # Add electricity plan data with prefix (issue #6)
+                for key, value in plans_data.items():
+                    combined_data[f"plan_{key}"] = value
 
             _LOGGER.info("Mercury coordinator: Combined data keys: %s", list(combined_data.keys()))
             _LOGGER.debug("Mercury coordinator: Sample data values: %s", {k: v for k, v in list(combined_data.items())[:5]})

--- a/custom_components/mercury_co_nz/manifest.json
+++ b/custom_components/mercury_co_nz/manifest.json
@@ -10,5 +10,5 @@
   "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.0"],
   "frontend": true,
   "min_ha_version": "2025.11.0",
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/custom_components/mercury_co_nz/mercury_api.py
+++ b/custom_components/mercury_co_nz/mercury_api.py
@@ -433,6 +433,132 @@ class MercuryAPI:
             _LOGGER.error("Error normalizing bill data: %s", exc)
             return {}
 
+    async def get_electricity_plans(self, _retry_count: int = 0) -> dict[str, Any]:
+        """Get electricity plan / current rate data from Mercury Energy.
+
+        Issue #6 — exposes the per-kWh rate so HACS dynamic_energy_cost can compute
+        per-appliance costs in real time. Mirrors the get_bill_summary shape but
+        also extracts service_id (the rates endpoint is per-ICP, not per-account).
+        """
+        _LOGGER.debug("Getting electricity plans data (retry count: %d)", _retry_count)
+
+        if not self._authenticated or not self._client:
+            success = await self.authenticate()
+            if not success:
+                _LOGGER.error("Authentication failed for electricity plans")
+                return {}
+
+        try:
+            loop = asyncio.get_event_loop()
+            _LOGGER.info("Getting electricity plans data...")
+
+            # Get account information
+            complete_data = await loop.run_in_executor(None, self._client.get_complete_account_data)
+            if not complete_data:
+                _LOGGER.error("No account data available")
+                return {}
+
+            customer_id = complete_data.customer_id
+            account_id = complete_data.account_ids[0] if complete_data.account_ids else None
+
+            if not customer_id or not account_id:
+                _LOGGER.error("Missing customer_id or account_id")
+                return {}
+
+            # Find electricity service (plans need service_id, like usage data)
+            electricity_service = None
+            for service in complete_data.services:
+                if service.is_electricity:
+                    electricity_service = service
+                    break
+
+            if not electricity_service:
+                _LOGGER.error("No electricity service found for plans data")
+                return {}
+
+            service_id = electricity_service.service_id
+
+            # Try to get plans using pymercury
+            try:
+                if hasattr(self._client, '_api_client') and hasattr(self._client._api_client, 'get_electricity_plans'):
+                    plans = await loop.run_in_executor(
+                        None,
+                        lambda: self._client._api_client.get_electricity_plans(customer_id, account_id, service_id)
+                    )
+                else:
+                    _LOGGER.warning("Electricity plans method not available in pymercury")
+                    return {}
+            except Exception as api_err:
+                _LOGGER.error("Error calling electricity plans API: %s", api_err)
+                return {}
+
+            if not plans:
+                _LOGGER.warning("No electricity plans data returned")
+                return {}
+
+            _LOGGER.info("Successfully retrieved electricity plans")
+            return self._normalize_plans_data(plans)
+
+        except Exception as exc:
+            if ("Tokens expired" in str(exc) or "refresh failed" in str(exc)) and _retry_count == 0:
+                _LOGGER.warning("Tokens expired, re-authenticating...")
+                self._authenticated = False
+                if await self.authenticate():
+                    return await self.get_electricity_plans(_retry_count + 1)
+
+            _LOGGER.error("Error fetching electricity plans: %s", exc, exc_info=True)
+            return {}
+
+    def _normalize_plans_data(self, plans_data: Any) -> dict[str, Any]:
+        """Normalize ElectricityPlans data to a flat dict.
+
+        CRITICAL: Mercury's anytime_rate and daily_fixed_charge are in NZ CENTS.
+        We divide by 100 here so the resulting sensor exposes NZD/kWh. HACS
+        dynamic_energy_cost parses only the /kWh denominator and labels output
+        with hass.config.currency — exposing raw cents would silently produce
+        100x wrong cost values.
+        """
+        if not plans_data:
+            return {}
+
+        try:
+            # Convert to dict if needed
+            if hasattr(plans_data, '__dict__'):
+                plans_dict = plans_data.__dict__
+            elif hasattr(plans_data, 'to_dict'):
+                plans_dict = plans_data.to_dict()
+            else:
+                plans_dict = plans_data
+
+            # Cents -> NZD conversion. `is not None` (not truthy) preserves a
+            # legitimate 0.0 rate (free-power period) instead of dropping it.
+            anytime_cents = plans_dict.get("anytime_rate")
+            daily_cents = plans_dict.get("daily_fixed_charge")
+
+            normalized = {
+                # Numeric (NZD)
+                "anytime_rate": round(float(anytime_cents) / 100.0, 6) if anytime_cents is not None else None,
+                "daily_fixed_charge": round(float(daily_cents) / 100.0, 6) if daily_cents is not None else None,
+                # Text
+                "current_plan_id": plans_dict.get("current_plan_id") or "",
+                "current_plan_name": plans_dict.get("current_plan_name") or "",
+                "current_plan_description": plans_dict.get("current_plan_description") or "",
+                "current_plan_usage_type": plans_dict.get("current_plan_usage_type") or "",
+                "icp_number": plans_dict.get("icp_number") or "",
+                "anytime_rate_measure": plans_dict.get("anytime_rate_measure") or "",
+                "plan_change_date": plans_dict.get("plan_change_date") or "",
+                # Booleans serialized as text (sensor-only platform)
+                "can_change_plan": "yes" if plans_dict.get("can_change_plan") else "no",
+                "is_pending_plan_change": "yes" if plans_dict.get("is_pending_plan_change") else "no",
+            }
+
+            _LOGGER.debug("Normalized plans data: %s", normalized)
+            return normalized
+
+        except Exception as exc:
+            _LOGGER.error("Error normalizing electricity plans data: %s", exc)
+            return {}
+
 
     async def _execute_api_call_with_fallback(self, api_method, customer_id, account_id, service_id,
                                             usage_key, history_key, log_message, success_message, error_message):

--- a/custom_components/mercury_co_nz/tests/test_plans.py
+++ b/custom_components/mercury_co_nz/tests/test_plans.py
@@ -1,0 +1,108 @@
+"""Unit tests for `MercuryAPI._normalize_plans_data` (issue #6).
+
+These tests guard the cents-to-NZD conversion. If they fail because someone
+removed the `/100.0` divisor, HACS dynamic_energy_cost would silently produce
+costs that are 100x too high.
+"""
+
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from custom_components.mercury_co_nz.mercury_api import MercuryAPI
+
+
+def _api() -> MercuryAPI:
+    """Construct a MercuryAPI without running __init__ (no session/email needed)."""
+    return MercuryAPI.__new__(MercuryAPI)
+
+
+def _ns(**kwargs) -> SimpleNamespace:
+    """Build a SimpleNamespace so `hasattr(__dict__)` succeeds in the helper."""
+    return SimpleNamespace(**kwargs)
+
+
+def test_normalize_converts_anytime_rate_cents_to_nzd() -> None:
+    """27.5 NZ cents/kWh -> 0.275 NZD/kWh."""
+    out = _api()._normalize_plans_data(_ns(anytime_rate=27.5))
+    assert out["anytime_rate"] == 0.275
+
+
+def test_normalize_converts_daily_fixed_charge_cents_to_nzd() -> None:
+    """137.0 NZ cents/day -> 1.37 NZD/day."""
+    out = _api()._normalize_plans_data(_ns(daily_fixed_charge=137.0))
+    assert out["daily_fixed_charge"] == 1.37
+
+
+def test_normalize_preserves_zero_rate() -> None:
+    """A free-power period (0.0) must NOT become None — `is not None` guard."""
+    out = _api()._normalize_plans_data(_ns(anytime_rate=0.0, daily_fixed_charge=0.0))
+    assert out["anytime_rate"] == 0.0
+    assert out["daily_fixed_charge"] == 0.0
+
+
+def test_normalize_returns_none_for_missing_rate() -> None:
+    """When pymercury hasn't populated the rate, output is None (sensor: unknown)."""
+    out = _api()._normalize_plans_data(_ns(current_plan_name="Anytime"))
+    assert out["anytime_rate"] is None
+    assert out["daily_fixed_charge"] is None
+    assert out["current_plan_name"] == "Anytime"
+
+
+def test_normalize_serializes_pending_plan_change() -> None:
+    """Booleans serialise to `yes`/`no` strings (sensor-only platform)."""
+    yes_out = _api()._normalize_plans_data(
+        _ns(is_pending_plan_change=True, can_change_plan=True)
+    )
+    no_out = _api()._normalize_plans_data(
+        _ns(is_pending_plan_change=False, can_change_plan=False)
+    )
+    assert yes_out["is_pending_plan_change"] == "yes"
+    assert yes_out["can_change_plan"] == "yes"
+    assert no_out["is_pending_plan_change"] == "no"
+    assert no_out["can_change_plan"] == "no"
+
+
+def test_normalize_handles_dict_input() -> None:
+    """If pymercury hands us a plain dict, the third fallback branch handles it.
+
+    A plain `dict` has no instance `__dict__` and no `to_dict()` method, so
+    the helper falls through to `plans_dict = plans_data`.
+    """
+    raw = {"anytime_rate": 30.0, "current_plan_name": "Low User"}
+    out = _api()._normalize_plans_data(raw)
+    assert out["anytime_rate"] == 0.3
+    assert out["current_plan_name"] == "Low User"
+
+
+def test_normalize_returns_empty_on_none_input() -> None:
+    """None / falsy input short-circuits to {}."""
+    assert _api()._normalize_plans_data(None) == {}
+    assert _api()._normalize_plans_data({}) == {}
+
+
+def test_normalize_full_record_round_trip() -> None:
+    """Sanity check on a realistic input — every field present."""
+    plans = _ns(
+        anytime_rate=29.95,
+        daily_fixed_charge=149.0,
+        current_plan_id="ANYTIME_2024",
+        current_plan_name="Anytime",
+        current_plan_description="Best for anytime users",
+        current_plan_usage_type="Standard",
+        icp_number="0000123456ABC78",
+        anytime_rate_measure="c/kWh",
+        plan_change_date="",
+        can_change_plan=True,
+        is_pending_plan_change=False,
+    )
+    out = _api()._normalize_plans_data(plans)
+    assert out["anytime_rate"] == 0.2995
+    assert out["daily_fixed_charge"] == 1.49
+    assert out["current_plan_id"] == "ANYTIME_2024"
+    assert out["current_plan_name"] == "Anytime"
+    assert out["icp_number"] == "0000123456ABC78"
+    assert out["anytime_rate_measure"] == "c/kWh"
+    assert out["can_change_plan"] == "yes"
+    assert out["is_pending_plan_change"] == "no"


### PR DESCRIPTION
## Summary

Closes #6 (`@ThundaNZ`'s suggestion). Expose Mercury's current electricity plan / per-kWh rate as five new sensors so HACS [`dynamic_energy_cost`](https://github.com/martinarva/dynamic_energy_cost) can compute per-appliance costs from real-time tariff data (driven by e.g. Tapo P110M smart-plug power readings).

## New sensors

| Entity                                     | Unit       | Notes                                        |
| ------------------------------------------ | ---------- | -------------------------------------------- |
| `sensor.mercury_nz_current_rate`           | `NZD/kWh`  | Per-kWh price (NZD, not cents)               |
| `sensor.mercury_nz_daily_fixed_charge`     | `NZD/day`  | Daily fixed charge from active plan          |
| `sensor.mercury_nz_current_plan`           | text       | Plan name (e.g. "Anytime", "Low User")       |
| `sensor.mercury_nz_icp_number`             | text       | ICP / Installation Control Point identifier  |
| `sensor.mercury_nz_plan_change_pending`    | `yes`/`no` | Surfaces upcoming plan transitions           |

## How it works

Pure-additive mirror of the existing `bill_summary` data source:

- New `MercuryAPI.get_electricity_plans()` method — 3-arg call (customer + account + service), calls pymercury 1.1.0's `client._api_client.get_electricity_plans(...)`, single-retry-on-token-expiry shape.
- New `_normalize_plans_data()` helper. **Critical**: divides `anytime_rate` and `daily_fixed_charge` by 100. Mercury reports rates in NZ cents; `dynamic_energy_cost` parses only the `/kWh` denominator and labels output with `hass.config.currency`, so exposing raw cents would silently produce 100× wrong cost values. Unit tests guard this.
- Coordinator merges the result with `plan_*` prefix alongside the existing `bill_*` / `monthly_*` / `weekly_*` / `content_*` prefixes.
- Five new `SENSOR_TYPES` entries; sensors auto-register via the existing `for sensor_type in SENSOR_TYPES` loop in `sensor.py` — no platform changes required.
- `device_class=None` (HA's monetary class only allows `state_class=total`, but a current rate is semantically `measurement` — Tibber's price sensor follows the same pattern).

## Test plan

- [x] `pytest custom_components/mercury_co_nz/tests/` — **42 passed** (34 existing from v1.1.0 + 8 new).
- [x] `mypy --follow-imports=silent --explicit-package-bases custom_components/mercury_co_nz/tests/test_plans.py` — clean.
- [x] `flake8` + `black --check` on new file — clean.
- [x] DST/recorder-aware tests from v1.1.0 still pass.
- [x] No regression: `git diff --stat` empty for `sensor.py`, `__init__.py`, `statistics.py`.
- [x] Unit tests guard the cents→NZD conversion (`anytime_rate=27.5` → `0.275`, `daily_fixed_charge=137.0` → `1.37`).
- [x] Zero-rate edge case (free-power period, `anytime_rate=0.0`) tested — `is not None` guard preserves it as `0.0`, not `None`.
- [ ] **Maintainer Level 5**: deploy via `./deploy.sh`, restart HA, confirm `sensor.mercury_nz_current_rate` shows numeric value matching real bill / 100. Configure `dynamic_energy_cost` and verify cost computations match a hand-calculation.

## Files changed

- 1 new: `tests/test_plans.py` (8 tests).
- 5 updated: `mercury_api.py` (+method +helper), `coordinator.py` (+fetch +merge), `const.py` (+5 SENSOR_TYPES), `manifest.json` (1.1.0 → 1.2.0), `README.md` (+section "Using with `dynamic_energy_cost`").

## Out of scope (deferred)

- Time-of-use (TOU) rate sensors — Mercury's `unit_rates` list can have multiple periods; v1 exposes only `anytime_rate`.
- Alternative-plan comparison (`standard_plans`, `low_plans`).
- Plan-change service calls.
- Gas / broadband rate sensors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)