### PR TITLE
fix: v1.2.2 — parse Mercury's '$0.2737' rate strings (#6)

### DIFF
--- a/custom_components/mercury_co_nz/manifest.json
+++ b/custom_components/mercury_co_nz/manifest.json
@@ -10,5 +10,5 @@
   "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.0"],
   "frontend": true,
   "min_ha_version": "2025.11.0",
-  "version": "1.2.1"
+  "version": "1.2.2"
 }

--- a/custom_components/mercury_co_nz/mercury_api.py
+++ b/custom_components/mercury_co_nz/mercury_api.py
@@ -563,14 +563,67 @@ class MercuryAPI:
             _LOGGER.error("Error fetching electricity plans: %s", exc, exc_info=True)
             return {}
 
+    @staticmethod
+    def _parse_rate_amount(value: Any, measure: str | None = None) -> float | None:
+        """Parse a Mercury rate value into a float in NZD per the unit (kWh/day).
+
+        Mercury's /electricity/plans endpoint returns rates as DISPLAY-FORMATTED
+        strings with a currency prefix — e.g. ``'$0.2737'`` for dollars-per-kWh,
+        or ``'27.37c'`` if Mercury ever serves a cents-form (defensive). Other
+        endpoints (bill, weekly, monthly) return numeric values, so this helper
+        lives only in the plans-data normalization path.
+
+        Args:
+            value: Mercury's rate value (string, int, float, or None).
+            measure: The companion rate_measure string (e.g. ``'$/kWh'``,
+                ``'c/kWh'``, or empty). Used to decide cents-to-dollars.
+
+        Returns:
+            Float in NZD per (kWh / day) — i.e. dollars, never cents.
+            ``None`` if the input is missing or unparseable.
+        """
+        if value is None:
+            return None
+
+        # If pymercury ever returns a numeric type, treat it as already
+        # canonical dollars. The current Mercury API delivers strings; this
+        # branch is defensive for future format changes.
+        if isinstance(value, (int, float)):
+            numeric = float(value)
+        else:
+            # Strip currency prefix/suffix and thousands separator.
+            cleaned = (
+                str(value)
+                .strip()
+                .replace("$", "")
+                .replace(",", "")
+                .rstrip("c")
+            )
+            try:
+                numeric = float(cleaned)
+            except ValueError:
+                _LOGGER.warning(
+                    "Mercury plans: could not parse rate %r (measure=%r); returning None",
+                    value, measure,
+                )
+                return None
+
+        # Cents -> dollars only if the measure explicitly says cents. Mercury
+        # actually returns dollars (verified by user runtime data); the cents
+        # branch is defensive for future format variation.
+        if measure and "c" in measure.lower() and "$" not in measure:
+            numeric = numeric / 100.0
+
+        return round(numeric, 6)
+
     def _normalize_plans_data(self, plans_data: Any) -> dict[str, Any]:
         """Normalize ElectricityPlans data to a flat dict.
 
-        CRITICAL: Mercury's anytime_rate and daily_fixed_charge are in NZ CENTS.
-        We divide by 100 here so the resulting sensor exposes NZD/kWh. HACS
-        dynamic_energy_cost parses only the /kWh denominator and labels output
-        with hass.config.currency — exposing raw cents would silently produce
-        100x wrong cost values.
+        Mercury's /electricity/plans endpoint serves rates as DISPLAY-FORMATTED
+        strings — typically '$0.2737' (dollars-per-kWh) for anytime_rate and
+        '$X.XX' for daily_fixed_charge. The `_parse_rate_amount` helper handles
+        the string -> float conversion and uses the rate_measure field to
+        disambiguate cents/dollars defensively.
         """
         if not plans_data:
             return {}
@@ -584,15 +637,16 @@ class MercuryAPI:
             else:
                 plans_dict = plans_data
 
-            # Cents -> NZD conversion. `is not None` (not truthy) preserves a
-            # legitimate 0.0 rate (free-power period) instead of dropping it.
-            anytime_cents = plans_dict.get("anytime_rate")
-            daily_cents = plans_dict.get("daily_fixed_charge")
+            anytime_raw = plans_dict.get("anytime_rate")
+            daily_raw = plans_dict.get("daily_fixed_charge")
+            anytime_measure = plans_dict.get("anytime_rate_measure")
+            # Mercury doesn't expose a separate measure for daily_fixed_charge
+            # in pymercury's model; it's per-day in dollars. Pass None.
 
             normalized = {
                 # Numeric (NZD)
-                "anytime_rate": round(float(anytime_cents) / 100.0, 6) if anytime_cents is not None else None,
-                "daily_fixed_charge": round(float(daily_cents) / 100.0, 6) if daily_cents is not None else None,
+                "anytime_rate": self._parse_rate_amount(anytime_raw, anytime_measure),
+                "daily_fixed_charge": self._parse_rate_amount(daily_raw, None),
                 # Text
                 "current_plan_id": plans_dict.get("current_plan_id") or "",
                 "current_plan_name": plans_dict.get("current_plan_name") or "",

--- a/custom_components/mercury_co_nz/mercury_api.py
+++ b/custom_components/mercury_co_nz/mercury_api.py
@@ -588,13 +588,17 @@ class MercuryAPI:
         # If pymercury ever returns a numeric type, treat it as already
         # canonical dollars. The current Mercury API delivers strings; this
         # branch is defensive for future format changes.
+        has_dollar_prefix = False
         if isinstance(value, (int, float)):
             numeric = float(value)
         else:
-            # Strip currency prefix/suffix and thousands separator.
+            raw_str = str(value).strip()
+            # Track the $ prefix BEFORE stripping it — the value's own currency
+            # symbol is a stronger signal than the `measure` field. If the
+            # value says dollars and the measure says cents, the value wins.
+            has_dollar_prefix = raw_str.startswith("$")
             cleaned = (
-                str(value)
-                .strip()
+                raw_str
                 .replace("$", "")
                 .replace(",", "")
                 .rstrip("c")
@@ -608,10 +612,15 @@ class MercuryAPI:
                 )
                 return None
 
-        # Cents -> dollars only if the measure explicitly says cents. Mercury
-        # actually returns dollars (verified by user runtime data); the cents
-        # branch is defensive for future format variation.
-        if measure and "c" in measure.lower() and "$" not in measure:
+        # Cents -> dollars only if the measure explicitly says cents AND the
+        # value itself wasn't dollar-prefixed. Mercury actually returns dollars
+        # today; the cents branch is defensive for future format variation.
+        if (
+            not has_dollar_prefix
+            and measure
+            and "c" in measure.lower()
+            and "$" not in measure
+        ):
             numeric = numeric / 100.0
 
         return round(numeric, 6)

--- a/custom_components/mercury_co_nz/tests/test_plans.py
+++ b/custom_components/mercury_co_nz/tests/test_plans.py
@@ -33,15 +33,18 @@ def _ns(**kwargs) -> SimpleNamespace:
     return SimpleNamespace(**kwargs)
 
 
-def test_normalize_converts_anytime_rate_cents_to_nzd() -> None:
-    """27.5 NZ cents/kWh -> 0.275 NZD/kWh."""
-    out = _api()._normalize_plans_data(_ns(anytime_rate=27.5))
+def test_normalize_anytime_rate_cents_form_with_measure() -> None:
+    """Defensive: if Mercury ever serves cents form ('27.5' with measure='c/kWh'),
+    the helper detects 'c' in the measure and divides by 100."""
+    out = _api()._normalize_plans_data(
+        _ns(anytime_rate="27.5", anytime_rate_measure="c/kWh")
+    )
     assert out["anytime_rate"] == 0.275
 
 
-def test_normalize_converts_daily_fixed_charge_cents_to_nzd() -> None:
-    """137.0 NZ cents/day -> 1.37 NZD/day."""
-    out = _api()._normalize_plans_data(_ns(daily_fixed_charge=137.0))
+def test_normalize_daily_fixed_charge_dollar_string() -> None:
+    """Mercury's actual format: '$1.37' string in dollars-per-day."""
+    out = _api()._normalize_plans_data(_ns(daily_fixed_charge="$1.37"))
     assert out["daily_fixed_charge"] == 1.37
 
 
@@ -78,9 +81,10 @@ def test_normalize_handles_dict_input() -> None:
     """If pymercury hands us a plain dict, the third fallback branch handles it.
 
     A plain `dict` has no instance `__dict__` and no `to_dict()` method, so
-    the helper falls through to `plans_dict = plans_data`.
+    the helper falls through to `plans_dict = plans_data`. Use Mercury's actual
+    string format ('$0.30').
     """
-    raw = {"anytime_rate": 30.0, "current_plan_name": "Low User"}
+    raw = {"anytime_rate": "$0.30", "current_plan_name": "Low User"}
     out = _api()._normalize_plans_data(raw)
     assert out["anytime_rate"] == 0.3
     assert out["current_plan_name"] == "Low User"
@@ -93,16 +97,19 @@ def test_normalize_returns_empty_on_none_input() -> None:
 
 
 def test_normalize_full_record_round_trip() -> None:
-    """Sanity check on a realistic input — every field present."""
+    """Sanity check on a realistic Mercury record — every field present.
+
+    Uses Mercury's actual string format ('$X.XXXX') for the rate fields.
+    """
     plans = _ns(
-        anytime_rate=29.95,
-        daily_fixed_charge=149.0,
+        anytime_rate="$0.2995",
+        daily_fixed_charge="$1.49",
         current_plan_id="ANYTIME_2024",
         current_plan_name="Anytime",
         current_plan_description="Best for anytime users",
         current_plan_usage_type="Standard",
         icp_number="0000123456ABC78",
-        anytime_rate_measure="c/kWh",
+        anytime_rate_measure="$/kWh",
         plan_change_date="",
         can_change_plan=True,
         is_pending_plan_change=False,
@@ -113,7 +120,7 @@ def test_normalize_full_record_round_trip() -> None:
     assert out["current_plan_id"] == "ANYTIME_2024"
     assert out["current_plan_name"] == "Anytime"
     assert out["icp_number"] == "0000123456ABC78"
-    assert out["anytime_rate_measure"] == "c/kWh"
+    assert out["anytime_rate_measure"] == "$/kWh"
     assert out["can_change_plan"] == "yes"
     assert out["is_pending_plan_change"] == "no"
 
@@ -251,3 +258,70 @@ async def test_get_electricity_plans_returns_empty_when_pymercury_returns_none(
         and "(A) get_services empty / no match" in m
         for m in msgs
     ), f"failure-mode hint not found in WARNING logs: {msgs}"
+
+
+# ----------------------------------------------------------------------------
+# v1.2.2 — _parse_rate_amount helper tests + regression for '$0.2737' bug
+# ----------------------------------------------------------------------------
+
+
+def test_parse_rate_amount_dollar_string() -> None:
+    """The actual format Mercury returns: '$0.2737' → 0.2737."""
+    assert MercuryAPI._parse_rate_amount("$0.2737", "$/kWh") == 0.2737
+
+
+def test_parse_rate_amount_dollar_with_thousands_separator() -> None:
+    """Defensive: '$1,234.56' → 1234.56."""
+    assert MercuryAPI._parse_rate_amount("$1,234.56", "$/day") == 1234.56
+
+
+def test_parse_rate_amount_cents_with_c_suffix() -> None:
+    """Defensive: if Mercury ever serves '27.5c' with measure='c/kWh' → 0.275 NZD."""
+    assert MercuryAPI._parse_rate_amount("27.5c", "c/kWh") == 0.275
+
+
+def test_parse_rate_amount_cents_with_explicit_measure() -> None:
+    """A bare numeric '27.5' string with measure='c/kWh' is interpreted as cents → 0.275 NZD."""
+    assert MercuryAPI._parse_rate_amount("27.5", "c/kWh") == 0.275
+
+
+def test_parse_rate_amount_numeric_dollars_passthrough() -> None:
+    """A bare float (no measure) is treated as already canonical dollars."""
+    assert MercuryAPI._parse_rate_amount(0.2737, None) == 0.2737
+
+
+def test_parse_rate_amount_returns_none_for_none() -> None:
+    assert MercuryAPI._parse_rate_amount(None, "$/kWh") is None
+
+
+def test_parse_rate_amount_returns_none_for_unparseable(caplog) -> None:
+    """Malformed input → None + WARNING log."""
+    with caplog.at_level(logging.WARNING):
+        result = MercuryAPI._parse_rate_amount("not a number", "$/kWh")
+    assert result is None
+    assert any("could not parse rate" in r.getMessage() for r in caplog.records)
+
+
+def test_parse_rate_amount_zero_is_preserved() -> None:
+    """Free-power period (0.0) must NOT become None."""
+    assert MercuryAPI._parse_rate_amount("$0.00", "$/kWh") == 0.0
+    assert MercuryAPI._parse_rate_amount(0, "$/kWh") == 0.0
+
+
+def test_normalize_handles_dollar_string_anytime_rate() -> None:
+    """Regression test for the bug from issue #6 logs.
+
+    Verifies that Mercury's actual `'$0.2737'` format does NOT raise ValueError
+    inside `_normalize_plans_data` and produces the correct float.
+    """
+    plans = _ns(
+        anytime_rate="$0.2737",
+        anytime_rate_measure="$/kWh",
+        daily_fixed_charge="$1.49",
+        current_plan_name="Anytime",
+    )
+    out = _api()._normalize_plans_data(plans)
+    assert out != {}, "normalize must not return empty dict for valid input"
+    assert out["anytime_rate"] == 0.2737
+    assert out["daily_fixed_charge"] == 1.49
+    assert out["current_plan_name"] == "Anytime"

--- a/custom_components/mercury_co_nz/tests/test_plans.py
+++ b/custom_components/mercury_co_nz/tests/test_plans.py
@@ -308,6 +308,13 @@ def test_parse_rate_amount_zero_is_preserved() -> None:
     assert MercuryAPI._parse_rate_amount(0, "$/kWh") == 0.0
 
 
+def test_parse_rate_amount_dollar_prefix_overrides_cents_measure() -> None:
+    """If value has $ prefix but measure says 'c/kWh' (inconsistent API),
+    trust the value's currency symbol — don't divide by 100."""
+    # $0.2737 with cents measure must STILL yield 0.2737, not 0.002737.
+    assert MercuryAPI._parse_rate_amount("$0.2737", "c/kWh") == 0.2737
+
+
 def test_normalize_handles_dollar_string_anytime_rate() -> None:
     """Regression test for the bug from issue #6 logs.
 


### PR DESCRIPTION
## Summary

Closes #6 (the actual root cause now confirmed and fixed).

The 5 plan_* sensors shipped in v1.2.0 (PR #8) silently failed for all users. v1.2.1's diagnostic logging release (PR #9) just deployed and surfaced the exact failure: `_normalize_plans_data` was raising `ValueError: could not convert string to float: '\$0.2737'`.

Mercury's `/electricity/plans` endpoint serves rates as **display-formatted strings** (e.g. `'\$0.2737'`, dollars-per-kWh) — NOT numeric values in cents as v1.2.0 assumed.

## Root Cause

Two bugs in the v1.2.0 line at `mercury_api.py:577`:

```python
"anytime_rate": round(float(anytime_cents) / 100.0, 6) if anytime_cents is not None else None,
```

1. ❌ `float('\$0.2737')` raises ValueError — Mercury sends a string with currency prefix.
2. ❌ Even if we stripped the `\$`, `/100.0` would make the value 100× too small. Mercury's value is already in NZD (`\$0.2737`/kWh).

The bug existed since v1.2.0's first commit. Verified against pymercury v1.0.5 and v1.1.0 — both extract this field identically (`rate.get('rate')` raw passthrough). Mercury's API has always returned the string format; my v1.2.0 normalize just assumed numeric cents based on incorrect docstring inference.

## Changes

| File | Change |
|------|--------|
| `mercury_api.py` | ADD `_parse_rate_amount(value, measure) -> float | None` static helper (~50 lines). UPDATE `_normalize_plans_data` to use the helper for both `anytime_rate` and `daily_fixed_charge`. |
| `manifest.json` | Version 1.2.1 → 1.2.2. |
| `tests/test_plans.py` | UPDATE 4 pre-existing tests that asserted the v1.2.0 buggy `/100.0` behaviour. ADD 9 new tests including the regression test for `'\$0.2737'`. |

The new `_parse_rate_amount` handles:
- ✅ `'\$0.2737'` → `0.2737` (Mercury's actual format)
- ✅ `'\$1,234.56'` → `1234.56` (defensive: thousands separator)
- ✅ `'27.5c'` + `measure='c/kWh'` → `0.275` (defensive: cents form)
- ✅ `'27.5'` + `measure='c/kWh'` → `0.275` (cents disambiguation via measure)
- ✅ `0.2737` (numeric) → `0.2737` (already canonical dollars)
- ✅ `None` → `None`
- ✅ `'not a number'` → `None` + WARNING log
- ✅ `'\$0.00'` → `0.0` (free-power period preserved, not None)

## Testing

- [x] **55 tests pass in 0.15s** (46 existing + 9 new helper/regression tests).
- [x] Black format check clean.
- [x] mypy clean (`--follow-imports=silent --explicit-package-bases`).
- [x] Smoke test against the exact bug input: `_parse_rate_amount('\$0.2737', '\$/kWh') == 0.2737` ✓

## Validation

```bash
.venv/bin/pytest -q custom_components/mercury_co_nz/tests/
.venv/bin/python -m black --check custom_components/mercury_co_nz/tests/test_plans.py
```

After merge + deploy:
1. Restart HA, wait one coordinator cycle (~5 min).
2. Confirm `sensor.mercury_nz_current_rate` shows a numeric NZD value matching your bill (e.g. `0.2737`).
3. Confirm no \"Error normalizing electricity plans data\" log lines.
4. Configure HACS dynamic_energy_cost with `sensor.mercury_nz_current_rate` as the price source — costs should compute correctly.

## Issue

Fixes #6.

---

<details>
<summary>📋 Implementation Details</summary>

### Implementation followed artifact: `.claude/PRPs/issues/issue-6-rate-parse-error.md`

### Deviations from plan

- The artifact called for adding 9 NEW tests but didn't explicitly say to update the 4 pre-existing tests. Those 4 tests asserted the v1.2.0 buggy behaviour (e.g. `_ns(anytime_rate=27.5)` → `0.275` because `27.5/100`); they would have failed against the new correct implementation. Updated them to use Mercury's actual string format (`'\$0.2737'`) so they validate the FIX rather than the bug.
- v1.2.1's diagnostic logging block stays in place. Will be removed in a v1.2.3 cleanup once we confirm 1.2.2 actually works in the field.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)