### PR TITLE
fix: v1.3.1 — correct state_class on windowed-sum sensors (#4 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,33 @@ custom_components/mercury_co_nz/
 2. Verify internet connectivity
 3. Restart Home Assistant integration
 
+### Unit Warnings After Upgrading to v1.2.3 or Later
+
+If you see warnings like:
+
+```
+The unit of sensor.mercury_nz_current_bill_7_days is changing, got multiple {None, '$'}
+The unit of sensor.mercury_nz_total_usage_7_days (None) cannot be converted to the unit of previously compiled statistics (kWh)
+The unit of sensor.mercury_nz_energy_usage (None) cannot be converted to the unit of previously compiled statistics (kWh)
+```
+
+…after upgrading to v1.2.3+, this is **expected residue** from prior versions where state attributes
+exceeded HA's 16 KB cap and `unit_of_measurement` was being dropped from the recorder. v1.2.3 fixed the
+upstream cause but stale state rows remain in HA's recorder DB until they age out (default ~10 days).
+
+**Quick fix** (one-time):
+
+1. Open **Developer Tools → Statistics** in Home Assistant.
+2. Find each affected entity (typically: `sensor.mercury_nz_energy_usage`,
+   `sensor.mercury_nz_total_usage_7_days`, `sensor.mercury_nz_current_bill_7_days`).
+3. Click **"Fix Issue"** next to each.
+4. Choose **"Update the unit"**.
+
+The warnings disappear immediately. This does NOT delete your sensor history or the Energy Dashboard
+statistics — those use a separate `mercury_co_nz:*` namespace and are unaffected.
+
+Alternatively, the warnings will resolve on their own once the stale state rows age out of HA's recorder.
+
 ## 📜 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/custom_components/mercury_co_nz/const.py
+++ b/custom_components/mercury_co_nz/const.py
@@ -36,7 +36,11 @@ SENSOR_TYPES = {
         "unit": "kWh",
         "icon": "mdi:lightning-bolt",
         "device_class": "energy",
-        "state_class": "total_increasing",
+        # state_class=total (not total_increasing): Mercury reports a windowed sum
+        # over the trailing 7 days. When the window rolls forward the value can
+        # decrease, which violates total_increasing's monotonic contract and
+        # corrupts long-term-stat accumulators.
+        "state_class": "total",
     },
     "energy_usage": {
         "name": "Energy Usage",
@@ -92,14 +96,16 @@ SENSOR_TYPES = {
         "unit": "kWh",
         "icon": "mdi:clock-outline",
         "device_class": "energy",
-        "state_class": "total_increasing",
+        # state_class=total — windowed sum over trailing 7 days, see total_usage above.
+        "state_class": "total",
     },
     "monthly_usage": {
         "name": "Monthly Usage (2 months)",
         "unit": "kWh",
         "icon": "mdi:calendar-month",
         "device_class": "energy",
-        "state_class": "total_increasing",
+        # state_class=total — windowed sum over trailing 2 months, see total_usage above.
+        "state_class": "total",
     },
     # Bill Summary Sensors
     "bill_account_id": {

--- a/custom_components/mercury_co_nz/manifest.json
+++ b/custom_components/mercury_co_nz/manifest.json
@@ -10,5 +10,5 @@
   "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.0"],
   "frontend": true,
   "min_ha_version": "2025.11.0",
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/custom_components/mercury_co_nz/tests/test_state_class.py
+++ b/custom_components/mercury_co_nz/tests/test_state_class.py
@@ -1,0 +1,63 @@
+"""Test invariants on SENSOR_TYPES state_class assignments (issue #4 follow-up).
+
+Background: HA's `total_increasing` contract requires monotonic non-decreasing
+values; decreases trigger "unexpected dip" warnings AND corrupt the
+`total_increasing` long-term-stat accumulator. Several Mercury sensors expose
+WINDOWED sums (last 7 days, last 2 months) — which decrease when the API
+window rolls — and were incorrectly tagged `total_increasing` since v1.0.0,
+silently producing bad stats and contributing to the recorder.py:335/:368
+unit-mix warnings the user reported after v1.2.3 deployed.
+
+These tests lock in the corrected state_class assignments and catch future
+regressions where someone adds a kWh/$ sensor without a state_class (which
+silently disables long-term statistics).
+"""
+
+from __future__ import annotations
+
+from custom_components.mercury_co_nz.const import SENSOR_TYPES
+
+
+def test_windowed_sum_sensors_not_total_increasing() -> None:
+    """Windowed-sum sensors must NOT use total_increasing.
+
+    Mercury exposes these as trailing-window aggregates whose value decreases
+    when the oldest sample drops out of the window — that breaks
+    total_increasing's monotonic contract.
+    """
+    windowed_sum_sensors = ("total_usage", "hourly_usage", "monthly_usage")
+    for sensor_type in windowed_sum_sensors:
+        config = SENSOR_TYPES[sensor_type]
+        assert config["state_class"] != "total_increasing", (
+            f"{sensor_type} is a windowed sum (value decreases when window rolls); "
+            "state_class=total_increasing violates HA's monotonic contract."
+        )
+
+
+def test_windowed_sum_sensors_use_total() -> None:
+    """The chosen replacement is `total`, not `measurement` or None.
+
+    `total` keeps long-term statistics enabled (unlike `measurement` for
+    energy device_class) and tolerates up/down values (unlike total_increasing).
+    """
+    windowed_sum_sensors = ("total_usage", "hourly_usage", "monthly_usage")
+    for sensor_type in windowed_sum_sensors:
+        assert SENSOR_TYPES[sensor_type]["state_class"] == "total", (
+            f"{sensor_type} state_class should be 'total' to participate in "
+            "long-term statistics with non-monotonic values."
+        )
+
+
+def test_state_class_present_for_numeric_sensors() -> None:
+    """Numeric sensors with kWh/$/rate units must declare a state_class.
+
+    Without it, HA silently skips long-term statistics — same failure mode the
+    user just hit, but harder to diagnose because there's no warning at all.
+    """
+    units_requiring_state_class = ("kWh", "$", "NZD/kWh", "NZD/day")
+    for sensor_type, config in SENSOR_TYPES.items():
+        if config.get("unit") in units_requiring_state_class:
+            assert config.get("state_class") is not None, (
+                f"{sensor_type} has unit {config['unit']!r} but no state_class — "
+                "long-term statistics will be silently skipped."
+            )


### PR DESCRIPTION
## Summary

Follow-up to PR #11 (v1.2.3 attribute-size fix). After v1.2.3 deployed, the user reported new unit-mix warnings:

```
recorder.py:335 — sensor.mercury_nz_current_bill_7_days is changing, got multiple {None, '$'}
recorder.py:368 — sensor.mercury_nz_total_usage_7_days (None) cannot be converted to (kWh)
recorder.py:368 — sensor.mercury_nz_energy_usage (None) cannot be converted to (kWh)
```

Two distinct things were going on:

1. **Transient residue** from the v1.2.3 fix — pre-v1.2.3 state rows have `unit=NULL` because their oversized attributes were dropped; HA's recorder reads recent history and sees the unit "change" between the stale rows and the new (correct) ones. **Resolved by user via Developer Tools → Statistics → "Update the unit"**, or auto-resolves as old rows age out (~10 days).

2. **Latent code bug** that was contributing to the noise — `total_usage`, `hourly_usage`, and `monthly_usage` were tagged `state_class=total_increasing` since v1.0.0, but they expose Mercury's windowed sums (last 7 days, last 7 days hourly, last 2 months). When the window rolls forward, their values **decrease** — which violates `total_increasing`'s monotonic contract and corrupts the long-term-stat accumulator. PR #7's investigation flagged this as out-of-scope at the time.

This PR fixes #2 (the code bug) and ships the README docs for #1 (the user fix path).

## Changes

| File | Change |
|------|--------|
| `custom_components/mercury_co_nz/const.py` | `state_class: total_increasing` → `total` for `total_usage`, `hourly_usage`, `monthly_usage`, with comments explaining why |
| `custom_components/mercury_co_nz/tests/test_state_class.py` | NEW — invariant tests: windowed-sum sensors must NOT be `total_increasing`; numeric sensors must declare a `state_class` |
| `README.md` | New troubleshooting section: "Unit Warnings After Upgrading to v1.2.3 or Later" with the Developer Tools → Statistics → Update the unit walkthrough |
| `custom_components/mercury_co_nz/manifest.json` | 1.3.0 → 1.3.1 |

## Why `total` and not `measurement` or `None`

- `total_increasing` requires monotonic non-decreasing → wrong for windowed sums.
- `total` allows up/down values and keeps long-term statistics enabled.
- `measurement` would lose the long-term-statistics integration entirely (energy device_class with `measurement` doesn't get summed).
- `None` would silently drop these sensors from the statistics system.

`total` is the same pattern `current_bill` already uses (also a windowed sum) and matches how Tibber/Octopus tag billing-period totals.

## Test plan

- [x] `pytest custom_components/mercury_co_nz/tests/` — 77 passed (3 new state_class invariant tests + 74 existing)
- [x] New tests fail when reverted to `total_increasing` (verified during development)
- [ ] After deploy + restart, run `Developer Tools → Statistics → Fix Issue → Update the unit` for the 3 affected entities — warnings disappear
- [ ] Confirm long-term statistics resume compiling for these 3 sensors over the next coordinator cycles
- [ ] Confirm Energy Dashboard (which uses `mercury_co_nz:*` external statistics from PR #7) is unaffected

## Related

- Closes follow-up of #4
- Builds on PR #11 (v1.2.3) which fixed the upstream attribute-size cause
- Related to PR #7 which originally flagged this latent issue as out-of-scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)