### PR TITLE
docs: v1.3.2 — clarify text plan sensors don't appear in Statistics tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,24 @@ custom_components/mercury_co_nz/
 2. Verify internet connectivity
 3. Restart Home Assistant integration
 
+### Plan Sensors Not Showing in Statistics Tab
+
+Three of the v1.2.0 plan sensors are **text-only** and won't appear in
+**Developer Tools → Statistics** (which only lists numeric long-term-stat
+sensors). They DO exist — look in **Developer Tools → States**:
+
+| Entity ID | Where to find it | Example state |
+|-----------|------------------|---------------|
+| `sensor.mercury_nz_current_plan` | States tab | `"Anytime"` (your plan name) |
+| `sensor.mercury_nz_icp_number` | States tab | `"0001263891UN390"` |
+| `sensor.mercury_nz_plan_change_pending` | States tab | `"yes"` / `"no"` |
+| `sensor.mercury_nz_current_rate` | States **and** Statistics tab | `0.2737` (NZD/kWh) |
+| `sensor.mercury_nz_daily_fixed_charge` | States **and** Statistics tab | `1.49` (NZD/day) |
+
+The first three have `state_class=None` and `unit=None` because their values
+are categorical strings, not measurements. HA's Statistics tab is a
+recorder-side feature for numeric sensors only; this is by design.
+
 ### Unit Warnings After Upgrading to v1.2.3 or Later
 
 If you see warnings like:

--- a/custom_components/mercury_co_nz/coordinator.py
+++ b/custom_components/mercury_co_nz/coordinator.py
@@ -120,6 +120,15 @@ class MercuryDataUpdateCoordinator(DataUpdateCoordinator):
                 # Add electricity plan data with prefix (issue #6)
                 for key, value in plans_data.items():
                     combined_data[f"plan_{key}"] = value
+                _LOGGER.info(
+                    "Mercury CO NZ: plan_* keys merged into coordinator data: %s",
+                    sorted(k for k in combined_data if k.startswith("plan_")),
+                )
+            else:
+                _LOGGER.warning(
+                    "Mercury CO NZ: get_electricity_plans returned empty/falsy data; "
+                    "all plan_* sensors will report None this cycle"
+                )
 
             _LOGGER.info("Mercury coordinator: Combined data keys: %s", list(combined_data.keys()))
             _LOGGER.debug("Mercury coordinator: Sample data values: %s", {k: v for k, v in list(combined_data.items())[:5]})

--- a/custom_components/mercury_co_nz/manifest.json
+++ b/custom_components/mercury_co_nz/manifest.json
@@ -10,5 +10,5 @@
   "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.0"],
   "frontend": true,
   "min_ha_version": "2025.11.0",
-  "version": "1.3.1"
+  "version": "1.3.2"
 }

--- a/custom_components/mercury_co_nz/sensor.py
+++ b/custom_components/mercury_co_nz/sensor.py
@@ -48,6 +48,12 @@ async def async_setup_entry(
         "Added %d Mercury sensors; primary chart entity is sensor.mercury_nz_energy_usage",
         len(entities),
     )
+    # Diagnostic — surfaces which sensor_types the integration tried to register so
+    # users investigating "missing sensor" reports can confirm registration happened.
+    _LOGGER.info(
+        "Mercury CO NZ: registered sensor_types: %s",
+        sorted(e._sensor_type for e in entities),
+    )
 
 
 class MercurySensor(CoordinatorEntity, SensorEntity):


### PR DESCRIPTION
## Summary

User reported missing plan sensors after v1.2.0:
> "mercury_nz_plan_change_pending, mercury_nz_icp_number, mercury_nz_current_plan. I can't find these sensors."

Diagnostic via Developer Tools → States confirmed: **entities are registered with real values** (e.g., \`current_plan = "Anytime"\`, \`icp_number = "0001263891UN390"\`, \`plan_change_pending = "no"\`). They simply don't appear in **Developer Tools → Statistics**, which is where the user looked first.

This is **working as designed**: HA's Statistics tab only lists entities with numeric \`state_class\` (\`measurement\`/\`total\`/\`total_increasing\`) and a \`unit_of_measurement\`. The 3 missing-from-Statistics sensors are text-only (\`state_class=None\`, \`unit=None\`) because their values are categorical strings, not measurements. They live in the States tab.

## Changes

| File | Change |
|------|--------|
| \`README.md\` | New troubleshooting section: "Plan Sensors Not Showing in Statistics Tab" with a table mapping each plan sensor to where it surfaces |
| \`sensor.py\` | INFO log of registered \`sensor_types\` after \`async_add_entities\` — diagnostic for future "missing sensor" reports |
| \`coordinator.py\` | Per-cycle INFO log of plan_* keys merged into \`combined_data\`; WARNING when \`get_electricity_plans\` returns empty data |
| \`manifest.json\` | 1.3.1 → 1.3.2 |

## Why no code-behavior change

I initially drafted a \`or "" → or None\` change in \`_normalize_plans_data\` so missing fields would show as \`unknown\` instead of empty string. Then user diagnostic confirmed the user's account *does* return values for all 3 fields — the original report wasn't about empty data, it was about looking in the wrong UI tab. The behavior change wasn't justified, so it was reverted before commit.

## Test plan

- [x] \`pytest custom_components/mercury_co_nz/tests/\` — 77 passed (unchanged, no test impact since no behavior change)
- [ ] After deploy + restart, check HA log for \`Mercury CO NZ: registered sensor_types: [...]\` and \`Mercury CO NZ: plan_* keys merged into coordinator data: [...]\` — confirms diagnostic logging works
- [ ] Verify the 3 plan sensors are still in Developer Tools → States with their values

🤖 Generated with [Claude Code](https://claude.com/claude-code)