### PR TITLE
feat: v1.4.0 — gas consumption in HA Energy Dashboard (monthly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,40 @@ Up to **180 days of historical data** are backfilled on first install (from the 
 3. Tick **Use an entity tracking the total costs**. Pick the `mercury_co_nz:...` cost statistic.
 4. (Optional but recommended) Set `homeassistant.currency: NZD` in `configuration.yaml` and restart, otherwise the dashboard cost labels may show `$` instead of `NZ$`.
 
+### Gas (auto-detected, monthly granularity) — v1.4.0+
+
+If your Mercury account includes gas service (alongside electricity, or gas-only), v1.4.0+ automatically imports gas consumption + cost into Home Assistant's Energy Dashboard at **monthly granularity**.
+
+**Why monthly only?** Mercury's gas API does not expose daily or hourly data — only monthly invoice-period aggregates. The integration emits one statistics entry per Mercury invoice period (typically one month), anchored at the end of the period.
+
+**What this looks like in HA:**
+
+- **Energy Dashboard → Monthly tab**: gas bars at correct totals per month — matches your Mercury bill. ✅
+- **Energy Dashboard → Daily / Hourly tabs**: a single bar per Mercury invoice period at `invoice_to`. The daily/hourly views still work but show monthly granularity — this is an honest representation of what Mercury actually provides (no synthetic sub-monthly distribution).
+- **Live `sensor.mercury_nz_gas_*` entities**: not provided in v1.4.0 (would require sub-monthly data Mercury doesn't expose).
+
+**Setup:**
+
+1. Restart Home Assistant after upgrading.
+2. Open **Settings → Energy → Add gas source**.
+3. Select **`Mercury <account-id> gas consumption`** as your gas usage source.
+4. (Optional) Select **`Mercury <account-id> gas cost`** as the gas cost stat.
+
+Mercury reports gas in kWh natively (NZ gas billing is energy-based); HA accepts kWh-denominated gas statistics directly when paired with `device_class=energy` (the same pattern Octopus Energy uses for UK gas).
+
+**Verify detection** in HA logs after restart:
+
+- `Mercury CO NZ: gas service detected; enabling gas statistics importer`
+- `Mercury CO NZ: gas_* keys merged into coordinator data: [...]`
+
+Gas statistics use the same `mercury_co_nz:<id_prefix>_*` namespace as electricity, just with different suffixes (`_gas_consumption` and `_gas_cost` vs `_energy_consumption` and `_energy_cost`).
+
 ### Notes
 
 - Mercury exposes per-hour usage in addition to daily totals. The integration prefers real per-hour values for the dashboard hourly view; days outside the hourly cache window fall back to a daily-total split evenly across 23/24/25 hours (DST-aware), so the trailing 180-day backfill is still smooth even before the hourly cache has filled.
 - Mercury bill corrections within the trailing 3 days are absorbed automatically (recent days are re-imported on every poll).
 - If you previously set up template-sensor + utility_meter workarounds for the Energy Dashboard, you can remove them after enabling these statistics.
+- Gas statistics (v1.4.0+) are monthly-granularity only — see the "Gas (auto-detected, monthly granularity)" section above.
 
 ## 📊 Using with `dynamic_energy_cost` (per-appliance cost tracking)
 

--- a/custom_components/mercury_co_nz/const.py
+++ b/custom_components/mercury_co_nz/const.py
@@ -329,6 +329,10 @@ FALLBACK_EMPTY_LIST = []
 # Statistics (Energy Dashboard integration)
 STATISTICS_ENERGY_SUFFIX: Final[str] = "energy_consumption"
 STATISTICS_COST_SUFFIX: Final[str] = "energy_cost"
+# Gas suffixes (v1.4.0). Mercury's gas API only returns monthly aggregates;
+# we emit one StatisticData per invoice period.
+STATISTICS_GAS_CONSUMPTION_SUFFIX: Final[str] = "gas_consumption"
+STATISTICS_GAS_COST_SUFFIX: Final[str] = "gas_cost"
 NZ_TIMEZONE: Final[str] = "Pacific/Auckland"
 STATISTICS_BACKFILL_DAYS: Final[int] = 180  # matches the daily JSON retention cap
 STATISTICS_HOURLY_RETENTION_DAYS: Final[int] = 180  # hourly cache retention; matches daily cap so Energy Dashboard hourly profile spans the same window

--- a/custom_components/mercury_co_nz/coordinator.py
+++ b/custom_components/mercury_co_nz/coordinator.py
@@ -35,7 +35,15 @@ class MercuryDataUpdateCoordinator(DataUpdateCoordinator):
             config[CONF_EMAIL],
             config[CONF_PASSWORD],
         )
+        self._email = config[CONF_EMAIL]
         self._statistics = MercuryStatisticsImporter(hass, config[CONF_EMAIL])
+
+        # Gas pipeline (v1.4.0) — lazily initialized on first cycle that detects a
+        # gas service in complete_data.services. Mercury's gas API only returns
+        # monthly aggregates, so the gas pipeline is much smaller than electricity:
+        # one fetch per cycle, no JSON cache, one StatisticData per invoice period.
+        self._gas_available: bool = False
+        self._gas_statistics: MercuryStatisticsImporter | None = None
 
         super().__init__(
             hass,
@@ -86,6 +94,34 @@ class MercuryDataUpdateCoordinator(DataUpdateCoordinator):
             usage_content_data = await self.api.get_usage_content()
             _LOGGER.info("Mercury coordinator: Received usage content data")
 
+            # Gas pipeline (v1.4.0) — lazy detection on first cycle, then fetch every cycle.
+            if not self._gas_available:
+                try:
+                    loop = asyncio.get_event_loop()
+                    complete_data = await loop.run_in_executor(
+                        None, self.api._client.get_complete_account_data
+                    )
+                    if complete_data and any(s.is_gas for s in complete_data.services):
+                        self._gas_available = True
+                        _LOGGER.info(
+                            "Mercury CO NZ: gas service detected; enabling gas statistics importer"
+                        )
+                        self._gas_statistics = MercuryStatisticsImporter(
+                            self.hass, self._email, fuel_type="gas"
+                        )
+                except Exception as exc:  # pylint: disable=broad-except
+                    _LOGGER.debug(
+                        "Gas availability check failed (will retry next cycle): %s", exc
+                    )
+
+            gas_data: dict[str, Any] | None = None
+            if self._gas_available:
+                try:
+                    gas_data = await self.api.get_gas_usage_data()
+                except Exception as exc:  # pylint: disable=broad-except
+                    _LOGGER.warning("Mercury gas usage fetch failed this cycle: %s", exc)
+                    gas_data = None
+
             _LOGGER.info("📋 Fetching electricity plans data...")
             plans_data = await self.api.get_electricity_plans()
             _LOGGER.info("Mercury coordinator: Received plans data")
@@ -128,6 +164,15 @@ class MercuryDataUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.warning(
                     "Mercury CO NZ: get_electricity_plans returned empty/falsy data; "
                     "all plan_* sensors will report None this cycle"
+                )
+
+            if gas_data:
+                # Add gas data with prefix to avoid collision with electricity keys.
+                for key, value in gas_data.items():
+                    combined_data[f"gas_{key}"] = value
+                _LOGGER.info(
+                    "Mercury CO NZ: gas_* keys merged into coordinator data: %s",
+                    sorted(k for k in combined_data if k.startswith("gas_")),
                 )
 
             _LOGGER.info("Mercury coordinator: Combined data keys: %s", list(combined_data.keys()))
@@ -194,6 +239,16 @@ class MercuryDataUpdateCoordinator(DataUpdateCoordinator):
                     exc,
                     exc_info=True,
                 )
+
+            if self._gas_statistics is not None:
+                try:
+                    await self._gas_statistics.async_update(combined_data)
+                except Exception as exc:  # pylint: disable=broad-except
+                    _LOGGER.error(
+                        "Mercury gas statistics import failed (Energy Dashboard gas section will be stale): %s",
+                        exc,
+                        exc_info=True,
+                    )
 
             return combined_data
         except Exception as exception:

--- a/custom_components/mercury_co_nz/manifest.json
+++ b/custom_components/mercury_co_nz/manifest.json
@@ -10,5 +10,5 @@
   "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.0"],
   "frontend": true,
   "min_ha_version": "2025.11.0",
-  "version": "1.3.2"
+  "version": "1.4.0"
 }

--- a/custom_components/mercury_co_nz/mercury_api.py
+++ b/custom_components/mercury_co_nz/mercury_api.py
@@ -927,6 +927,78 @@ class MercuryAPI:
                 _LOGGER.error("❌ Error fetching electricity usage data: %s", exc, exc_info=True)
                 return {}
 
+    async def get_gas_usage_data(self) -> dict[str, Any]:
+        """Fetch monthly gas usage from Mercury (v1.4.0).
+
+        Mercury's gas API only returns useful data at interval='monthly'.
+        pymercury exposes get_gas_usage(interval='daily') and
+        get_gas_usage_hourly but Mercury responds with empty `usage` arrays
+        for both — confirmed via maintainer testing — so we only call
+        get_gas_usage_monthly.
+
+        Returns a dict whose keys the coordinator will prefix with `gas_`
+        before merging into `combined_data`. The statistics importer reads
+        `gas_monthly_usage_history` and emits one StatisticData entry per
+        Mercury invoice period.
+        """
+        try:
+            loop = asyncio.get_event_loop()
+            complete_data = await loop.run_in_executor(
+                None, self._client.get_complete_account_data
+            )
+            if not complete_data:
+                return {}
+
+            account_id = (
+                complete_data.account_ids[0] if complete_data.account_ids else None
+            )
+
+            gas_service = None
+            for service in complete_data.services:
+                if service.is_gas:
+                    gas_service = service
+                    break
+
+            if not gas_service:
+                _LOGGER.debug("No gas service found; skipping gas usage fetch")
+                return {}
+
+            customer_id = complete_data.customer_id
+            service_id = gas_service.service_id
+
+            gas_monthly = await loop.run_in_executor(
+                None,
+                self._client._api_client.get_gas_usage_monthly,
+                customer_id, account_id, service_id,
+            )
+
+            if not gas_monthly:
+                _LOGGER.warning("Mercury get_gas_usage_monthly returned None")
+                return {}
+
+            # Each entry in gas_monthly.daily_usage represents an INVOICE PERIOD
+            # (typically one month) — name is misleading because pymercury reuses
+            # ServiceUsage's daily_usage list regardless of the request interval.
+            monthly_history = list(getattr(gas_monthly, "daily_usage", []) or [])
+
+            _LOGGER.info(
+                "Mercury gas: %d monthly entries, %.2f kWh total, $%.2f total",
+                len(monthly_history),
+                getattr(gas_monthly, "total_usage", 0) or 0,
+                getattr(gas_monthly, "total_cost", 0) or 0,
+            )
+
+            return {
+                "monthly_usage": round(float(getattr(gas_monthly, "total_usage", 0) or 0), DECIMAL_PLACES),
+                "monthly_cost": round(float(getattr(gas_monthly, "total_cost", 0) or 0), DECIMAL_PLACES),
+                "monthly_data_points": getattr(gas_monthly, "data_points", 0),
+                "monthly_usage_history": monthly_history,
+                "service_id": service_id,
+            }
+        except Exception as exc:  # pylint: disable=broad-except
+            _LOGGER.error("Mercury gas usage fetch failed: %s", exc, exc_info=True)
+            return {}
+
     def _process_electricity_usage(self, usage: Any) -> dict[str, Any]:
         """Process ElectricityUsage object into normalized sensor data."""
         normalized_data = {}

--- a/custom_components/mercury_co_nz/statistics.py
+++ b/custom_components/mercury_co_nz/statistics.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import hashlib
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, Literal
 from zoneinfo import ZoneInfo
 
 from homeassistant.components import persistent_notification
@@ -33,6 +33,8 @@ from .const import (
     STATISTICS_ENERGY_SUFFIX,
     STATISTICS_FAILURE_BACKOFF_THRESHOLD,
     STATISTICS_FAILURE_NOTIFICATION_THRESHOLD,
+    STATISTICS_GAS_CONSUMPTION_SUFFIX,
+    STATISTICS_GAS_COST_SUFFIX,
     STATISTICS_REIMPORT_DAYS,
 )
 
@@ -57,15 +59,29 @@ class MercuryStatisticsImporter:
     the daily total split evenly across 23/24/25 hours (DST-aware).
     """
 
-    def __init__(self, hass: HomeAssistant, email: str) -> None:
-        """Initialise; schedule async load of any persisted id_prefix."""
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        email: str,
+        fuel_type: Literal["electricity", "gas"] = "electricity",
+    ) -> None:
+        """Initialise; schedule async load of any persisted id_prefix.
+
+        fuel_type defaults to "electricity" so the existing single-arg
+        construction in coordinator.py keeps working byte-identically.
+        Electricity Store key MUST stay as f"{DOMAIN}_statistics_{email_hash}"
+        — existing users have their id_prefix locked under that key; renaming
+        would orphan every existing electricity series.
+        """
         self._hass = hass
         self._email = email
+        self._fuel_type = fuel_type
         self._email_hash = hashlib.md5(email.encode()).hexdigest()[:8]
+        store_key_suffix = "" if fuel_type == "electricity" else f"_{fuel_type}"
         self._store: Store = Store(
             hass,
             version=_STORE_VERSION,
-            key=f"{DOMAIN}_statistics_{self._email_hash}",
+            key=f"{DOMAIN}_statistics{store_key_suffix}_{self._email_hash}",
         )
         self._id_prefix: str | None = None
         self._consecutive_failures: int = 0
@@ -109,13 +125,24 @@ class MercuryStatisticsImporter:
         (verified against HA 2025.11+ recorder/models/statistics.py). `unit_class=None`
         for cost skips unit conversion so any string (including "NZD") is accepted.
         """
-        energy_statistic_id = f"{DOMAIN}:{id_prefix}_{STATISTICS_ENERGY_SUFFIX}"
-        cost_statistic_id = f"{DOMAIN}:{id_prefix}_{STATISTICS_COST_SUFFIX}"
+        if self._fuel_type == "gas":
+            consumption_suffix = STATISTICS_GAS_CONSUMPTION_SUFFIX
+            cost_suffix = STATISTICS_GAS_COST_SUFFIX
+            consumption_name = f"Mercury {id_prefix} gas consumption"
+            cost_name = f"Mercury {id_prefix} gas cost"
+        else:
+            consumption_suffix = STATISTICS_ENERGY_SUFFIX
+            cost_suffix = STATISTICS_COST_SUFFIX
+            consumption_name = f"Mercury {id_prefix} consumption"
+            cost_name = f"Mercury {id_prefix} cost"
+
+        energy_statistic_id = f"{DOMAIN}:{id_prefix}_{consumption_suffix}"
+        cost_statistic_id = f"{DOMAIN}:{id_prefix}_{cost_suffix}"
 
         energy_meta = StatisticMetaData(
             mean_type=StatisticMeanType.NONE,
             has_sum=True,
-            name=f"Mercury {id_prefix} consumption",
+            name=consumption_name,
             source=DOMAIN,
             statistic_id=energy_statistic_id,
             unit_class=EnergyConverter.UNIT_CLASS,
@@ -124,7 +151,7 @@ class MercuryStatisticsImporter:
         cost_meta = StatisticMetaData(
             mean_type=StatisticMeanType.NONE,
             has_sum=True,
-            name=f"Mercury {id_prefix} cost",
+            name=cost_name,
             source=DOMAIN,
             statistic_id=cost_statistic_id,
             unit_class=None,
@@ -151,6 +178,99 @@ class MercuryStatisticsImporter:
         last_sum = entry.get("sum")
         last_start = entry.get("start")
         return float(last_sum if last_sum is not None else 0.0), last_start
+
+    @staticmethod
+    def _parse_invoice_end_utc(raw: str) -> datetime | None:
+        """Parse Mercury's invoice_to / month-start string into hour-aligned UTC.
+
+        Accepts:
+        - Full ISO with offset: '2026-04-30T10:00:00+13:00'
+        - Naive datetime: '2026-04-30T00:00:00' (assumed NZ-local)
+        - Date-only: '2026-04-30' (assumed NZ-local midnight)
+
+        Returns None on parse failure so the caller can increment its skip counter.
+        """
+        if not isinstance(raw, str) or not raw.strip():
+            return None
+        s = raw.strip()
+        nz = ZoneInfo(NZ_TIMEZONE)
+        try:
+            if "T" not in s:
+                # Date-only — treat as NZ-local midnight at the start of that day.
+                parsed = datetime.strptime(s, "%Y-%m-%d").replace(tzinfo=nz)
+            else:
+                parsed = datetime.fromisoformat(s.replace("Z", "+00:00"))
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=nz)
+        except ValueError:
+            return None
+        utc = parsed.astimezone(timezone.utc)
+        return utc.replace(minute=0, second=0, microsecond=0)
+
+    @staticmethod
+    def _build_monthly_entries(
+        monthly_records: list[dict[str, Any]],
+        energy_sum_start: float,
+        cost_sum_start: float,
+        cutoff_ts: float,
+    ) -> tuple[list[StatisticData], list[StatisticData], int]:
+        """Build one StatisticData per Mercury invoice period (gas only).
+
+        Mercury's gas API only returns monthly aggregates. Each input record
+        represents an invoice period with `consumption` (kWh), `cost` (NZD),
+        `invoice_from`, `invoice_to`, and `date`. We anchor the entry at
+        invoice_to (end of period) — consumption "completed" by then —
+        hour-aligned to UTC. Sums accumulate chronologically so the series
+        is strictly monotonic.
+
+        Mirrors the (signature, return-tuple, skip-counter) contract of
+        `_build_hourly_entries` so async_update can branch on fuel_type
+        without changing the surrounding flow.
+        """
+        skipped = 0
+        # invoice_to_utc -> (kwh, cost)
+        buckets: dict[datetime, tuple[float, float]] = {}
+
+        for record in monthly_records or []:
+            invoice_to_raw = record.get("invoice_to") or record.get("date")
+            if not isinstance(invoice_to_raw, str):
+                skipped += 1
+                continue
+            anchor = MercuryStatisticsImporter._parse_invoice_end_utc(invoice_to_raw)
+            if anchor is None:
+                skipped += 1
+                continue
+            consumption = record.get("consumption")
+            cost = record.get("cost")
+            if consumption is None or cost is None:
+                skipped += 1
+                continue
+            buckets[anchor] = (float(consumption), float(cost))
+
+        # Filter out records already imported (anchor at or before cutoff).
+        # `energy_sum_start` represents the recorder's cumulative sum at the
+        # last imported entry, so new emissions accumulate from there — pre-cutoff
+        # buckets must NOT contribute or we double-count.
+        sorted_anchors = [
+            a for a in sorted(buckets.keys()) if a.timestamp() > cutoff_ts
+        ]
+        energy_running = float(energy_sum_start or 0.0)
+        cost_running = float(cost_sum_start or 0.0)
+        energy_stats: list[StatisticData] = []
+        cost_stats: list[StatisticData] = []
+
+        for anchor in sorted_anchors:
+            kwh, cost = buckets[anchor]
+            energy_running += kwh
+            cost_running += cost
+            energy_stats.append(
+                StatisticData(start=anchor, state=kwh, sum=energy_running)
+            )
+            cost_stats.append(
+                StatisticData(start=anchor, state=cost, sum=cost_running)
+            )
+
+        return energy_stats, cost_stats, skipped
 
     @staticmethod
     def _parse_hour_start_utc(record: dict[str, Any]) -> datetime | None:
@@ -342,22 +462,31 @@ class MercuryStatisticsImporter:
             )
             self._currency_warning_emitted = True
 
-        # 3. Pull daily records (extended history preferred for backfill) and
-        #    hourly records (real per-hour data, preferred over the daily split
-        #    for any NZ-local day they cover).
-        daily_records = (
-            coordinator_data.get("extended_daily_usage_history")
-            or coordinator_data.get("daily_usage_history")
-            or []
-        )
-        hourly_records = (
-            coordinator_data.get("extended_hourly_usage_history")
-            or coordinator_data.get("hourly_usage_history")
-            or []
-        )
-        if not daily_records and not hourly_records:
-            _LOGGER.debug("Mercury statistics: no usage records available; skipping")
-            return
+        # 3. Pull records based on fuel_type. Electricity uses daily+hourly
+        #    (with daily-split fallback); gas uses monthly only (Mercury's API
+        #    doesn't expose sub-monthly gas data — confirmed via maintainer testing).
+        if self._fuel_type == "gas":
+            monthly_records = coordinator_data.get("gas_monthly_usage_history") or []
+            daily_records: list[dict[str, Any]] = []
+            hourly_records: list[dict[str, Any]] = []
+            if not monthly_records:
+                _LOGGER.debug("Mercury statistics (gas): no monthly records available; skipping")
+                return
+        else:
+            monthly_records = []
+            daily_records = (
+                coordinator_data.get("extended_daily_usage_history")
+                or coordinator_data.get("daily_usage_history")
+                or []
+            )
+            hourly_records = (
+                coordinator_data.get("extended_hourly_usage_history")
+                or coordinator_data.get("hourly_usage_history")
+                or []
+            )
+            if not daily_records and not hourly_records:
+                _LOGGER.debug("Mercury statistics: no usage records available; skipping")
+                return
 
         # 4. Recorder readiness gate (only failure type swallowed locally).
         try:
@@ -399,13 +528,21 @@ class MercuryStatisticsImporter:
                 last_ts_energy or 0.0
             ) - STATISTICS_REIMPORT_DAYS * 86400
 
-            energy_stats, cost_stats, null_skip_count = self._build_hourly_entries(
-                daily_records,
-                hourly_records,
-                last_sum_energy or 0.0,
-                last_sum_cost or 0.0,
-                cutoff_ts,
-            )
+            if self._fuel_type == "gas":
+                energy_stats, cost_stats, null_skip_count = self._build_monthly_entries(
+                    monthly_records,
+                    last_sum_energy or 0.0,
+                    last_sum_cost or 0.0,
+                    cutoff_ts,
+                )
+            else:
+                energy_stats, cost_stats, null_skip_count = self._build_hourly_entries(
+                    daily_records,
+                    hourly_records,
+                    last_sum_energy or 0.0,
+                    last_sum_cost or 0.0,
+                    cutoff_ts,
+                )
 
             if not energy_stats and not cost_stats:
                 _LOGGER.debug(

--- a/custom_components/mercury_co_nz/tests/test_gas_pipeline.py
+++ b/custom_components/mercury_co_nz/tests/test_gas_pipeline.py
@@ -1,0 +1,245 @@
+"""Tests for gas-pipeline plumbing (v1.4.0).
+
+Covers:
+- Fuel-aware Store key (electricity must remain unsuffixed for back-compat)
+- Fuel-aware metadata (gas suffixes + names)
+- _build_monthly_entries logic (one entry per invoice period, monotonic sums,
+  cutoff dedup, null/missing handling, hour-aligned UTC anchors)
+
+Mercury's gas API only exposes monthly aggregates, so the gas importer reads
+`gas_monthly_usage_history` and produces one StatisticData entry per Mercury
+invoice period anchored at invoice_to.
+"""
+
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from custom_components.mercury_co_nz.const import (
+    DOMAIN,
+    STATISTICS_GAS_CONSUMPTION_SUFFIX,
+    STATISTICS_GAS_COST_SUFFIX,
+)
+from custom_components.mercury_co_nz.statistics import MercuryStatisticsImporter
+
+
+def _consume_coro(coro):
+    """Close a coroutine without awaiting (avoid ResourceWarning in pure tests)."""
+    coro.close()
+
+
+def _make_gas_importer() -> MercuryStatisticsImporter:
+    hass = MagicMock()
+    hass.async_create_task = _consume_coro
+    hass.config.currency = "NZD"
+    return MercuryStatisticsImporter(hass, "user@example.com", fuel_type="gas")
+
+
+def _make_elec_importer() -> MercuryStatisticsImporter:
+    hass = MagicMock()
+    hass.async_create_task = _consume_coro
+    hass.config.currency = "NZD"
+    return MercuryStatisticsImporter(hass, "user@example.com")  # default electricity
+
+
+def _record(invoice_to: str, consumption: float, cost: float) -> dict:
+    """Build a Mercury monthly usage record dict.
+
+    Mirrors the shape of pymercury's ServiceUsage.daily_usage entries
+    (which also contains monthly entries when interval='monthly').
+    """
+    return {
+        "date": invoice_to[:10],
+        "consumption": consumption,
+        "cost": cost,
+        "free_power": False,
+        "invoice_from": "",
+        "invoice_to": invoice_to,
+    }
+
+
+# ----------------------------------------------------------------------------
+# Fuel-aware Store key (LOAD-BEARING — guards electricity back-compat)
+# ----------------------------------------------------------------------------
+
+
+def test_store_key_back_compat_for_electricity() -> None:
+    """LOAD-BEARING: electricity Store key must NOT include any fuel suffix.
+
+    Existing v1.3.x users have their id_prefix locked under
+    f'{DOMAIN}_statistics_{email_hash}'. If this changes on upgrade,
+    the lock is lost — every existing electricity series gets an
+    'ID changed' ERROR and statistics import is suppressed.
+    """
+    elec = _make_elec_importer()
+    gas = _make_gas_importer()
+    assert elec._store.key == f"{DOMAIN}_statistics_{elec._email_hash}"
+    assert gas._store.key == f"{DOMAIN}_statistics_gas_{gas._email_hash}"
+    assert elec._store.key != gas._store.key
+
+
+def test_electricity_importer_default_constructor_unchanged() -> None:
+    """Single-arg construction (no fuel_type kwarg) still produces electricity.
+
+    The coordinator's existing call site `MercuryStatisticsImporter(hass, email)`
+    must continue producing electricity statistics with the existing
+    statistic_id suffixes — back-compat for the electricity importer.
+    """
+    importer = _make_elec_importer()
+    energy_meta, _ = importer._build_metadata("acc1")
+    assert "energy_consumption" in energy_meta["statistic_id"]
+    assert "gas_consumption" not in energy_meta["statistic_id"]
+
+
+# ----------------------------------------------------------------------------
+# Fuel-aware metadata
+# ----------------------------------------------------------------------------
+
+
+def test_gas_importer_uses_gas_suffix() -> None:
+    importer = _make_gas_importer()
+    energy_meta, cost_meta = importer._build_metadata("acc1")
+    assert energy_meta["statistic_id"] == f"{DOMAIN}:acc1_{STATISTICS_GAS_CONSUMPTION_SUFFIX}"
+    assert cost_meta["statistic_id"] == f"{DOMAIN}:acc1_{STATISTICS_GAS_COST_SUFFIX}"
+
+
+def test_gas_importer_name_says_gas() -> None:
+    importer = _make_gas_importer()
+    energy_meta, cost_meta = importer._build_metadata("acc1")
+    assert "gas" in energy_meta["name"].lower()
+    assert "gas" in cost_meta["name"].lower()
+
+
+# ----------------------------------------------------------------------------
+# _build_monthly_entries
+# ----------------------------------------------------------------------------
+
+
+def test_monthly_entries_one_per_invoice_period() -> None:
+    records = [
+        _record("2026-02-01T00:00:00+13:00", 100.0, 25.0),
+        _record("2026-03-01T00:00:00+13:00", 80.0, 20.0),
+        _record("2026-04-01T00:00:00+13:00", 120.0, 30.0),
+    ]
+    energy, cost, skipped = MercuryStatisticsImporter._build_monthly_entries(
+        records, energy_sum_start=0.0, cost_sum_start=0.0, cutoff_ts=0.0
+    )
+    assert len(energy) == 3
+    assert len(cost) == 3
+    assert skipped == 0
+
+
+def test_monthly_entries_sums_are_monotonic() -> None:
+    records = [
+        _record("2026-02-01T00:00:00+13:00", 100.0, 25.0),
+        _record("2026-03-01T00:00:00+13:00", 80.0, 20.0),
+        _record("2026-04-01T00:00:00+13:00", 120.0, 30.0),
+    ]
+    energy, cost, _ = MercuryStatisticsImporter._build_monthly_entries(
+        records, energy_sum_start=0.0, cost_sum_start=0.0, cutoff_ts=0.0
+    )
+    assert [e["sum"] for e in energy] == [100.0, 180.0, 300.0]
+    assert [c["sum"] for c in cost] == [25.0, 45.0, 75.0]
+
+
+def test_monthly_entries_skip_records_at_or_before_cutoff() -> None:
+    """Cutoff dedup: entries already imported in prior cycles are not re-emitted,
+    but their consumption is still added to the running sum so subsequent
+    entries continue monotonically from where the recorder left off."""
+    records = [
+        _record("2026-02-01T00:00:00+13:00", 100.0, 25.0),
+        _record("2026-03-01T00:00:00+13:00", 80.0, 20.0),
+        _record("2026-04-01T00:00:00+13:00", 120.0, 30.0),
+    ]
+    # Cutoff just past Feb 1 UTC (Feb 1 NZDT = Jan 31 11:00 UTC) — first record dropped.
+    cutoff = datetime(2026, 1, 31, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+    energy, _, skipped = MercuryStatisticsImporter._build_monthly_entries(
+        records,
+        energy_sum_start=100.0,    # carry-over from Feb already in recorder
+        cost_sum_start=25.0,
+        cutoff_ts=cutoff,
+    )
+    assert skipped == 0   # null_skip counts only parse/missing failures, not cutoff
+    assert len(energy) == 2  # Mar + Apr emitted; Feb skipped via cutoff
+    # First emitted entry (March) sum continues from Feb's carry (100) + March (80) = 180
+    assert energy[0]["sum"] == 180.0
+    assert energy[1]["sum"] == 300.0
+
+
+def test_monthly_entries_skip_null_consumption() -> None:
+    """Future-period estimates may have null consumption — skip and count."""
+    records = [
+        {"invoice_to": "2026-02-01T00:00:00+13:00", "consumption": None, "cost": None},
+        _record("2026-03-01T00:00:00+13:00", 80.0, 20.0),
+    ]
+    energy, _, skipped = MercuryStatisticsImporter._build_monthly_entries(
+        records, energy_sum_start=0.0, cost_sum_start=0.0, cutoff_ts=0.0
+    )
+    assert skipped == 1
+    assert len(energy) == 1
+
+
+def test_monthly_entries_skip_missing_invoice_to_and_date() -> None:
+    """Records with neither invoice_to nor date can't be anchored — skip."""
+    records = [
+        {"consumption": 100.0, "cost": 25.0},  # no anchor at all
+        _record("2026-03-01T00:00:00+13:00", 80.0, 20.0),
+    ]
+    energy, _, skipped = MercuryStatisticsImporter._build_monthly_entries(
+        records, energy_sum_start=0.0, cost_sum_start=0.0, cutoff_ts=0.0
+    )
+    assert skipped == 1
+    assert len(energy) == 1
+
+
+def test_monthly_entries_anchor_is_hour_aligned_utc() -> None:
+    """All emitted entries must have hour-aligned UTC start (recorder requirement)."""
+    records = [_record("2026-04-01T13:30:45+13:00", 100.0, 25.0)]
+    energy, _, _ = MercuryStatisticsImporter._build_monthly_entries(
+        records, energy_sum_start=0.0, cost_sum_start=0.0, cutoff_ts=0.0
+    )
+    anchor = energy[0]["start"]
+    assert anchor.tzinfo is not None
+    assert anchor.utcoffset().total_seconds() == 0  # UTC
+    assert anchor.minute == 0
+    assert anchor.second == 0
+    assert anchor.microsecond == 0
+
+
+def test_monthly_entries_falls_back_to_date_when_invoice_to_missing() -> None:
+    """Records with only `date` (no invoice_to) still produce entries."""
+    records = [
+        {"date": "2026-03-31", "consumption": 80.0, "cost": 20.0},
+    ]
+    energy, _, skipped = MercuryStatisticsImporter._build_monthly_entries(
+        records, energy_sum_start=0.0, cost_sum_start=0.0, cutoff_ts=0.0
+    )
+    assert skipped == 0
+    assert len(energy) == 1
+
+
+def test_monthly_entries_handles_unsorted_input() -> None:
+    """Records may arrive out of order from Mercury — sums must still be monotonic
+    after internal sort."""
+    records = [
+        _record("2026-04-01T00:00:00+13:00", 120.0, 30.0),  # latest first
+        _record("2026-02-01T00:00:00+13:00", 100.0, 25.0),
+        _record("2026-03-01T00:00:00+13:00", 80.0, 20.0),
+    ]
+    energy, _, _ = MercuryStatisticsImporter._build_monthly_entries(
+        records, energy_sum_start=0.0, cost_sum_start=0.0, cutoff_ts=0.0
+    )
+    sums = [e["sum"] for e in energy]
+    assert sums == sorted(sums)
+    assert sums == [100.0, 180.0, 300.0]
+
+
+def test_monthly_entries_empty_input_returns_empty() -> None:
+    energy, cost, skipped = MercuryStatisticsImporter._build_monthly_entries(
+        [], energy_sum_start=0.0, cost_sum_start=0.0, cutoff_ts=0.0
+    )
+    assert energy == []
+    assert cost == []
+    assert skipped == 0

--- a/custom_components/mercury_co_nz/tests/test_statistics.py
+++ b/custom_components/mercury_co_nz/tests/test_statistics.py
@@ -327,6 +327,62 @@ async def test_async_update_id_flip_logs_error_and_does_not_write(hass, caplog) 
     assert any("ID changed" in rec.message for rec in caplog.records)
 
 
+async def test_async_update_first_run_for_gas_emits_monthly_entries(hass) -> None:
+    """Gas importer with monthly records emits 2 stats with gas-suffixed IDs."""
+    importer = MercuryStatisticsImporter(hass, "test@example.com", fuel_type="gas")
+    await hass.async_block_till_done()
+
+    mock_recorder = MagicMock()
+
+    async def _exec(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    mock_recorder.async_add_executor_job = _exec
+
+    with patch(
+        "custom_components.mercury_co_nz.statistics.get_instance",
+        return_value=mock_recorder,
+    ), patch(
+        "custom_components.mercury_co_nz.statistics.get_last_statistics",
+        return_value={},
+    ), patch(
+        "custom_components.mercury_co_nz.statistics.async_add_external_statistics"
+    ) as mock_add:
+        coordinator_data = {
+            "bill_account_id": "ACC1",
+            "gas_monthly_usage_history": [
+                {
+                    "date": "2026-02-01",
+                    "consumption": 100.0,
+                    "cost": 25.0,
+                    "invoice_from": "2026-02-01T00:00:00+13:00",
+                    "invoice_to": "2026-03-01T00:00:00+13:00",
+                },
+                {
+                    "date": "2026-03-01",
+                    "consumption": 80.0,
+                    "cost": 20.0,
+                    "invoice_from": "2026-03-01T00:00:00+13:00",
+                    "invoice_to": "2026-04-01T00:00:00+13:00",
+                },
+            ],
+        }
+        await importer.async_update(coordinator_data)
+
+    assert mock_add.call_count == 2
+    metas = [call.args[1] for call in mock_add.call_args_list]
+    stat_ids = sorted(m["statistic_id"] for m in metas)
+    assert stat_ids == [
+        f"{DOMAIN}:acc1_gas_consumption",
+        f"{DOMAIN}:acc1_gas_cost",
+    ]
+    # Verify the entries themselves: 2 invoice periods → 2 entries each, monotonic sums
+    energy_call = next(c for c in mock_add.call_args_list if "consumption" in c.args[1]["statistic_id"])
+    energy_entries = energy_call.args[2]
+    assert len(energy_entries) == 2
+    assert [e["sum"] for e in energy_entries] == [100.0, 180.0]
+
+
 async def test_async_update_recorder_unavailable_increments_failure_count(
     hass,
 ) -> None:


### PR DESCRIPTION
## Summary

Mercury reports gas in kWh at monthly granularity (its API does not expose daily/hourly gas data — pymercury's \`get_gas_usage(interval='daily')\` and \`get_gas_usage_hourly\` exist but Mercury returns empty \`usage\` arrays). v1.4.0 adds a parallel gas pipeline that emits one \`StatisticData\` entry per Mercury invoice period to HA's Energy Dashboard.

Single-fuel electricity users see byte-identical behavior — \`fuel_type\` defaults to \`\"electricity\"\` and the electricity Store key stays unsuffixed so existing id_prefix locks survive the upgrade.

## Why kWh + \`device_class=energy\` for gas?

HA's Energy Dashboard's Gas section accepts kWh-denominated stats via \`device_class=energy\` ([core/validate.py L44-61](https://github.com/home-assistant/core/blob/dev/homeassistant/components/energy/validate.py)). Mercury's gas data is already in kWh (NZ gas billing is energy-based). Octopus Energy uses the same pattern for UK gas. No m³ conversion required.

## What changed

| File | Change |
|------|--------|
| \`const.py\` | \`STATISTICS_GAS_CONSUMPTION_SUFFIX\`, \`STATISTICS_GAS_COST_SUFFIX\` constants |
| \`mercury_api.py\` | NEW \`get_gas_usage_data()\` — single \`get_gas_usage_monthly\` call returning gas-prefixed dict |
| \`statistics.py\` | \`MercuryStatisticsImporter\` accepts \`fuel_type\` kwarg (default \"electricity\"). NEW \`_build_monthly_entries\` + \`_parse_invoice_end_utc\` (one entry per invoice period anchored at \`invoice_to\`, hour-aligned UTC, monotonic sums, cutoff-aware re-import). Electricity Store key preserved unchanged — **load-bearing** for back-compat. |
| \`coordinator.py\` | Lazy gas-service detection; instantiates gas importer iff gas exists; gas fetch + \`gas_\` prefix merge + gas \`async_update\` call |
| \`tests/test_gas_pipeline.py\` NEW | 13 tests: Store-key invariant (load-bearing), fuel-aware metadata, \`_build_monthly_entries\` (sums, cutoff dedup, null/missing, hour alignment, unsorted input) |
| \`tests/test_statistics.py\` | + gas integration smoke test (\`test_async_update_first_run_for_gas_emits_monthly_entries\`) |
| \`README.md\` | New \"Gas (auto-detected, monthly granularity)\" section explicitly documenting monthly-only caveat |
| \`manifest.json\` | 1.3.2 → 1.4.0 |

## What this looks like in HA

- **Energy Dashboard → Monthly tab**: gas bars at correct totals per month — matches Mercury bills. ✅
- **Energy Dashboard → Daily / Hourly tabs**: one bar per Mercury invoice period at \`invoice_to\`. Honest representation; no synthetic sub-monthly distribution.
- **Live \`sensor.mercury_nz_gas_*\`**: not provided (would require sub-monthly data Mercury doesn't expose).

## Test plan

- [x] \`pytest custom_components/mercury_co_nz/tests/\` → 91 passed (77 existing + 13 new gas pipeline + 1 new gas integration smoke)
- [x] All electricity tests pass byte-unchanged with fuel_type default → back-compat verified for existing users
- [x] Load-bearing test \`test_store_key_back_compat_for_electricity\` guards the electricity Store key invariant
- [ ] **Manual (multi-fuel user — maintainer's account is electricity-only)**: Settings → Energy → Add gas source → select \`Mercury <acct> gas consumption\`; confirm monthly bars appear after a coordinator cycle.
- [x] Manual (electricity-only regression): \`Mercury CO NZ: gas service detected\` should NOT appear in log; only 2 statistic_ids in Developer Tools → Statistics; existing electricity statistics continue accruing.

## Side benefit

Gas-only Mercury customers (rare) had a totally empty integration before — every fetch hit the \`if not electricity_service: return {}\` guard. v1.4.0 doesn't fix that for the electricity-side wrappers (out of scope), but their gas Energy Dashboard data now flows correctly via the new pipeline.

## Caveats

- **No multi-fuel tester for manual validation.** Maintainer's account is electricity-only. Asking for early-adopter feedback from any user with a Mercury electricity+gas or gas-only account.
- **Daily/hourly Energy Dashboard tabs show one bar per Mercury invoice period for gas.** This is honest — Mercury's API only provides monthly aggregates. README documents this explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)