### PR TITLE
fix: v1.4.1 — pin pymercury 1.1.1 (gas usage data fix)

### DIFF
--- a/custom_components/mercury_co_nz/manifest.json
+++ b/custom_components/mercury_co_nz/manifest.json
@@ -7,8 +7,8 @@
   "documentation": "https://github.com/bkintanar/home-assistant-mercury-co-nz",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.0"],
+  "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.1"],
   "frontend": true,
   "min_ha_version": "2025.11.0",
-  "version": "1.4.0"
+  "version": "1.4.1"
 }


### PR DESCRIPTION
## Summary

Bumps pymercury \`>=1.1.0\` → \`>=1.1.1\` to pick up the gas-envelope-detection fix that was the actual blocker for v1.4.0's gas pipeline returning empty data on real accounts.

## Background

After shipping v1.4.0 (PR #15), a multi-fuel user reported gas not appearing in HA's Energy Dashboard. Investigation timeline:

1. Initial hypothesis: pymercury's \`?includeAll=false\` default was hiding the gas Service from \`complete_data.services\`. **Disproven** by user-side diagnostic — default already exposes gas: \`'gas' / 'Piped' / 80101901093\`.
2. Refined hypothesis: Mercury's gas usage API genuinely returns no data for piped-gas accounts (no smart meter). **Partially correct** — but pymercury 1.1.0's envelope parser was also broken.
3. **Actual root cause**: pymercury 1.1.0's gas-usage parser couldn't extract \`usage_data\` from Mercury's response envelope even when the API returned data. Per pymercury 1.1.1's changelog (commit \`b5111ca\`):

> Gas usage IS now visible at the monthly interval (10 data points).
> Daily/hourly return zero because Mercury rarely exposes sub-monthly gas data for non-smart meters — that's a real-world API behavior.

## Changes

| File | Change |
|------|--------|
| \`manifest.json\` | \`mercury-co-nz-api>=1.1.0\` → \`>=1.1.1\`; version \`1.4.0\` → \`1.4.1\` |

**No integration code changes.** pymercury 1.1.1's API surface is identical to 1.1.0; only the internal envelope-detection logic changed. All 91 existing tests pass byte-unchanged against pymercury 1.1.1.

## Test plan

- [x] \`pip install --upgrade mercury-co-nz-api==1.1.1\` in venv
- [x] \`pytest custom_components/mercury_co_nz/tests/\` → 91 passed (no regressions)
- [ ] **Manual (multi-fuel user)**: After deploy + restart, check HA log for \`Mercury gas: N monthly entries\` where N is non-zero. Then **Settings → Energy → Add gas source** → select \`Mercury <acct> gas consumption\`. Confirm monthly bars appear in Energy Dashboard's gas section.

## Caveats (carried over from v1.4.0)

- **Daily/hourly Energy Dashboard tabs still show one bar per Mercury invoice period for gas.** Mercury doesn't expose sub-monthly gas data for non-smart meters — pymercury 1.1.1's changelog confirms this is real-world API behavior, not a parser limitation. README's "Gas (auto-detected, monthly granularity)" section already documents this.
- **Single-fuel electricity users are unaffected.** No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)