### PR TITLE
feat: v1.5.0 — multi-ICP foundation (Phase 1 of v2.0.0)

### DIFF
--- a/custom_components/mercury_co_nz/const.py
+++ b/custom_components/mercury_co_nz/const.py
@@ -333,6 +333,29 @@ STATISTICS_COST_SUFFIX: Final[str] = "energy_cost"
 # we emit one StatisticData per invoice period.
 STATISTICS_GAS_CONSUMPTION_SUFFIX: Final[str] = "gas_consumption"
 STATISTICS_GAS_COST_SUFFIX: Final[str] = "gas_cost"
+
+# Multi-ICP scope split (v2.0.0).
+# ICP-scoped: per-meter values from get_usage_data() / get_electricity_plans().
+# Multiplied per ICP in sensor.py — primary ICP keeps legacy entity_id,
+# secondary ICPs get ICP-token-prefixed entity_ids.
+# Account-scoped (everything NOT in this set): bill_*, weekly_*, monthly_*,
+# customer_id — single instance attached to the parent "Mercury Account" device.
+ICP_SCOPED_SENSOR_TYPES: Final[frozenset[str]] = frozenset({
+    "total_usage",
+    "energy_usage",
+    "current_bill",
+    "latest_daily_usage",
+    "latest_daily_cost",
+    "average_temperature",
+    "current_temperature",
+    "hourly_usage",
+    "monthly_usage",
+    "plan_anytime_rate",
+    "plan_daily_fixed_charge",
+    "plan_current_plan_name",
+    "plan_icp_number",
+    "plan_is_pending_plan_change",
+})
 NZ_TIMEZONE: Final[str] = "Pacific/Auckland"
 STATISTICS_BACKFILL_DAYS: Final[int] = 180  # matches the daily JSON retention cap
 STATISTICS_HOURLY_RETENTION_DAYS: Final[int] = 180  # hourly cache retention; matches daily cap so Energy Dashboard hourly profile spans the same window

--- a/custom_components/mercury_co_nz/manifest.json
+++ b/custom_components/mercury_co_nz/manifest.json
@@ -10,5 +10,5 @@
   "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.1"],
   "frontend": true,
   "min_ha_version": "2025.11.0",
-  "version": "1.4.1"
+  "version": "1.5.0"
 }

--- a/custom_components/mercury_co_nz/statistics.py
+++ b/custom_components/mercury_co_nz/statistics.py
@@ -44,6 +44,17 @@ _NOTIFICATION_ID = "mercury_co_nz_statistics_failed"
 _STORE_VERSION = 1
 
 
+def _sanitize_for_key(service_id: str | None) -> str:
+    """Sanitize a service_id for use in Store keys, statistic_ids, entity_ids.
+
+    Replaces dashes/dots with underscores and lowercases. Used both here
+    and in coordinator.py for consistent ICP token generation.
+    """
+    if not service_id:
+        return "primary"
+    return str(service_id).replace("-", "_").replace(".", "_").lower()
+
+
 class MercuryStatisticsImporter:
     """Push Mercury kWh + NZD costs into HA's long-term statistics table.
 
@@ -64,24 +75,35 @@ class MercuryStatisticsImporter:
         hass: HomeAssistant,
         email: str,
         fuel_type: Literal["electricity", "gas"] = "electricity",
+        service_id: str | None = None,
+        is_primary: bool = True,
     ) -> None:
         """Initialise; schedule async load of any persisted id_prefix.
 
-        fuel_type defaults to "electricity" so the existing single-arg
-        construction in coordinator.py keeps working byte-identically.
-        Electricity Store key MUST stay as f"{DOMAIN}_statistics_{email_hash}"
-        — existing users have their id_prefix locked under that key; renaming
-        would orphan every existing electricity series.
+        Default args (fuel_type='electricity', service_id=None, is_primary=True)
+        produce byte-identical Store key, statistic_ids, and names to v1.4.1 —
+        single-arg construction continues to work for back-compat.
+
+        For multi-ICP (v2.0.0): non-primary ICPs include an icp_token suffix
+        in the Store key AND in statistic_ids. Primary ICP keeps the legacy
+        formula so existing users' id_prefix lock + Energy Dashboard history
+        survive the upgrade.
         """
         self._hass = hass
         self._email = email
         self._fuel_type = fuel_type
+        self._service_id = service_id
+        self._is_primary = is_primary
         self._email_hash = hashlib.md5(email.encode()).hexdigest()[:8]
-        store_key_suffix = "" if fuel_type == "electricity" else f"_{fuel_type}"
+        fuel_suffix = "" if fuel_type == "electricity" else f"_{fuel_type}"
+        # LOAD-BEARING: only non-primary ICPs add the icp_suffix. Primary's
+        # Store key MUST match v1.4.1 exactly: f"{DOMAIN}_statistics_{email_hash}"
+        # for elec, f"{DOMAIN}_statistics_gas_{email_hash}" for gas.
+        icp_suffix = "" if is_primary else f"_{_sanitize_for_key(service_id)}"
         self._store: Store = Store(
             hass,
             version=_STORE_VERSION,
-            key=f"{DOMAIN}_statistics{store_key_suffix}_{self._email_hash}",
+            key=f"{DOMAIN}_statistics{fuel_suffix}{icp_suffix}_{self._email_hash}",
         )
         self._id_prefix: str | None = None
         self._consecutive_failures: int = 0
@@ -128,16 +150,19 @@ class MercuryStatisticsImporter:
         if self._fuel_type == "gas":
             consumption_suffix = STATISTICS_GAS_CONSUMPTION_SUFFIX
             cost_suffix = STATISTICS_GAS_COST_SUFFIX
-            consumption_name = f"Mercury {id_prefix} gas consumption"
-            cost_name = f"Mercury {id_prefix} gas cost"
+            fuel_word = "gas "
         else:
             consumption_suffix = STATISTICS_ENERGY_SUFFIX
             cost_suffix = STATISTICS_COST_SUFFIX
-            consumption_name = f"Mercury {id_prefix} consumption"
-            cost_name = f"Mercury {id_prefix} cost"
+            fuel_word = ""
 
-        energy_statistic_id = f"{DOMAIN}:{id_prefix}_{consumption_suffix}"
-        cost_statistic_id = f"{DOMAIN}:{id_prefix}_{cost_suffix}"
+        # LOAD-BEARING: only non-primary ICPs add the icp_token. Primary's
+        # statistic_id MUST match v1.4.1 exactly: e.g. f"{DOMAIN}:{id_prefix}_energy_consumption"
+        icp_token = "" if self._is_primary else f"_{_sanitize_for_key(self._service_id)}"
+        consumption_name = f"Mercury {id_prefix}{icp_token} {fuel_word}consumption".replace("  ", " ").strip()
+        cost_name = f"Mercury {id_prefix}{icp_token} {fuel_word}cost".replace("  ", " ").strip()
+        energy_statistic_id = f"{DOMAIN}:{id_prefix}{icp_token}_{consumption_suffix}"
+        cost_statistic_id = f"{DOMAIN}:{id_prefix}{icp_token}_{cost_suffix}"
 
         energy_meta = StatisticMetaData(
             mean_type=StatisticMeanType.NONE,

--- a/custom_components/mercury_co_nz/tests/test_gas_pipeline.py
+++ b/custom_components/mercury_co_nz/tests/test_gas_pipeline.py
@@ -243,3 +243,42 @@ def test_monthly_entries_empty_input_returns_empty() -> None:
     assert energy == []
     assert cost == []
     assert skipped == 0
+
+
+# ----------------------------------------------------------------------------
+# v2.0.0 — multi-ICP × gas composition
+# ----------------------------------------------------------------------------
+
+
+def test_gas_importer_with_secondary_icp_has_compound_store_key() -> None:
+    """Gas + non-primary ICP must have BOTH fuel and icp suffixes in the
+    Store key so the lock doesn't collide with primary gas or other gas ICPs."""
+    hass = MagicMock()
+    hass.async_create_task = _consume_coro
+    hass.config.currency = "NZD"
+    gas_secondary = MercuryStatisticsImporter(
+        hass,
+        "user@example.com",
+        fuel_type="gas",
+        service_id="ICP_GAS_002",
+        is_primary=False,
+    )
+    assert "_gas_" in gas_secondary._store.key
+    assert "icp_gas_002" in gas_secondary._store.key.lower()
+
+
+def test_gas_primary_icp_back_compat_store_key_unchanged() -> None:
+    """LOAD-BEARING: gas primary ICP Store key must match v1.4.1 byte-for-byte —
+    the existing fuel_type='gas' construction with default service_id/is_primary
+    produces f"{DOMAIN}_statistics_gas_{email_hash}" as before, no icp suffix.
+    """
+    from custom_components.mercury_co_nz.const import DOMAIN
+
+    hass = MagicMock()
+    hass.async_create_task = _consume_coro
+    hass.config.currency = "NZD"
+    # Default is_primary=True, service_id=None
+    gas_primary = MercuryStatisticsImporter(
+        hass, "user@example.com", fuel_type="gas"
+    )
+    assert gas_primary._store.key == f"{DOMAIN}_statistics_gas_{gas_primary._email_hash}"


### PR DESCRIPTION
## Summary

Phase 1 of the v2.0.0 multi-ICP plan (\`.claude/PRPs/plans/multi-icp-support.plan.md\`). Pure additive foundation work — zero user-visible behavior change, all 91 existing tests pass byte-unchanged, plus 2 new tests guarding the back-compat invariant.

## Why Phase 1 alone?

The v2.0.0 plan has 14 tasks across 5 phases (~1500 lines of careful refactoring). Phases 2-5 require:
- Phase 2: refactor 5 mercury_api wrappers to return per-service dicts
- Phase 3: coordinator dict-of-importers + per-ICP merge + per-ICP JSON files
- Phase 4: sensor.py per-ICP entity multiplication + parent/child DeviceInfo
- Phase 5: async_migrate_entry + MINOR_VERSION bump + multi-ICP tests + README

Shipping Phase 1+2 without Phase 3 leaves the runtime broken (coordinator expects flat dicts, refactored wrappers return per-service shape). Phase 1 alone is back-compat-preserving and ships valuable foundation.

## Changes

| File | Change |
|------|--------|
| \`const.py\` | NEW \`ICP_SCOPED_SENSOR_TYPES\` frozenset (14 per-meter keys; 25 account-level identified by exclusion) |
| \`statistics.py\` | \`MercuryStatisticsImporter\` accepts \`service_id\` and \`is_primary\` kwargs (defaults preserve v1.4.1 behavior). \`_build_metadata\` extends with ICP token for non-primary stats |
| \`tests/test_gas_pipeline.py\` | +2 tests: gas+secondary-ICP store key compound; gas+primary-ICP back-compat unchanged |
| \`manifest.json\` | 1.4.1 → 1.5.0 |

## LOAD-BEARING back-compat invariant

All 91 existing tests pass byte-unchanged. Default \`is_primary=True, service_id=None\` produces byte-identical Store key, statistic_ids, and names as v1.4.1:
- Electricity Store key: \`mercury_co_nz_statistics_<email_hash>\`
- Gas Store key: \`mercury_co_nz_statistics_gas_<email_hash>\`
- statistic_ids: \`mercury_co_nz:<acct>_energy_consumption\` etc

## Test plan

- [x] \`pytest custom_components/mercury_co_nz/tests/\` — 93 passed (91 existing + 2 new)
- [x] Existing 91 tests pass byte-unchanged with default-args path
- [ ] No multi-ICP runtime testing yet (Phase 3+4 not shipped)
- [ ] @LanlinkNZ to test full v2.0.0 once Phases 2-5 land

## Next steps

Follow-up PR ships Phases 2-5 with the actual user-visible multi-ICP behavior. Tagged \`@LanlinkNZ\` on issue #5 for testing once that PR is ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)