### PR TITLE
fix: v1.5.1 — pin pymercury 1.1.2

### DIFF
--- a/custom_components/mercury_co_nz/manifest.json
+++ b/custom_components/mercury_co_nz/manifest.json
@@ -7,8 +7,8 @@
   "documentation": "https://github.com/bkintanar/home-assistant-mercury-co-nz",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.1"],
+  "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.2"],
   "frontend": true,
   "min_ha_version": "2025.11.0",
-  "version": "1.5.0"
+  "version": "1.5.1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 # These are automatically installed by Home Assistant from manifest.json
 
 aiohttp>=3.8.0
-mercury-co-nz-api>=1.1.0
+mercury-co-nz-api>=1.1.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ homeassistant>=2025.11.0
 # Core dependencies
 aiohttp>=3.8.0
 voluptuous>=0.13.0
-mercury-co-nz-api>=1.1.0
+mercury-co-nz-api>=1.1.2
 
 # Development tools
 black>=22.0.0


### PR DESCRIPTION
## Summary
- Bump `mercury-co-nz-api` lower bound `>=1.1.1` → `>=1.1.2` in `manifest.json` so HA re-resolves and existing installs pull the fixed pymercury on update.
- Bump integration `version` `1.5.0` → `1.5.1` so HACS surfaces an update prompt.
- Align `requirements.txt` and `requirements_dev.txt` for local-dev parity (HA only reads `manifest.json`).

No integration code changes.

## Why both changes are needed
Home Assistant pip-installs `manifest.json` `requirements` on integration load and caches per integration. It only re-resolves when the constraint string changes — a HACS reinstall alone would leave existing users on whatever cached 1.1.x already satisfied `>=1.1.1`. The version bump is what tells HACS to surface an update.

## Test plan
- [ ] HACS shows v1.5.1 update prompt on a test HA instance running v1.5.0.
- [ ] After update + restart, `pip show mercury-co-nz-api` reports 1.1.2 (not 1.1.1).
- [ ] Existing electricity + gas sensors continue to populate (no regression from the pymercury bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)