### PR TITLE
fix: v1.5.2 — gas dashboard 164,220 kWh on 27 Mar (pair-collapse + sum baseline)

### DIFF
--- a/custom_components/mercury_co_nz/const.py
+++ b/custom_components/mercury_co_nz/const.py
@@ -359,7 +359,6 @@ ICP_SCOPED_SENSOR_TYPES: Final[frozenset[str]] = frozenset({
 NZ_TIMEZONE: Final[str] = "Pacific/Auckland"
 STATISTICS_BACKFILL_DAYS: Final[int] = 180  # matches the daily JSON retention cap
 STATISTICS_HOURLY_RETENTION_DAYS: Final[int] = 180  # hourly cache retention; matches daily cap so Energy Dashboard hourly profile spans the same window
-STATISTICS_REIMPORT_DAYS: Final[int] = 3  # always re-import last N days to absorb Mercury bill corrections
 STATISTICS_FAILURE_NOTIFICATION_THRESHOLD: Final[int] = 3  # consecutive failures before user-visible notification
 STATISTICS_FAILURE_BACKOFF_THRESHOLD: Final[int] = 12  # consecutive failures (≈1 hour) before stopping retries
 

--- a/custom_components/mercury_co_nz/manifest.json
+++ b/custom_components/mercury_co_nz/manifest.json
@@ -10,5 +10,5 @@
   "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.2"],
   "frontend": true,
   "min_ha_version": "2025.11.0",
-  "version": "1.5.1"
+  "version": "1.5.2"
 }

--- a/custom_components/mercury_co_nz/manifest.json
+++ b/custom_components/mercury_co_nz/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://github.com/bkintanar/home-assistant-mercury-co-nz",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.2"],
+  "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.3"],
   "frontend": true,
   "min_ha_version": "2025.11.0",
   "version": "1.5.2"

--- a/custom_components/mercury_co_nz/mercury_api.py
+++ b/custom_components/mercury_co_nz/mercury_api.py
@@ -26,6 +26,53 @@ except ImportError as e:
             raise ImportError("pymercury library is required but not available")
 
 
+def _collapse_gas_pairs(entries: list[dict]) -> list[dict]:
+    """Collapse Mercury's parallel (estimate, actual) gas pair structure.
+
+    Mercury returns each gas billing period as TWO entries — one in the
+    'estimate' group and one in 'actual', with one zero and one non-zero
+    per pair. pymercury 1.1.2's `daily_usage` flattens both groups, so a
+    naive `dict[anchor] = ...` bucketize in the statistics importer lets
+    the second-written entry clobber the first, losing ~half the periods'
+    real values.
+
+    Pick the entry with the larger non-zero consumption for each
+    `(invoice_from, invoice_to)` window. Ties break to actual
+    (`is_estimated=False`) so a fully-zero pair still picks the actual
+    entry. Returned in chronological order on `(invoice_to, date)`.
+
+    pymercury 1.1.3+ exposes `ServiceUsage.consumption_periods` which
+    pre-collapses upstream; once the floor is bumped, prefer that and
+    drop this helper.
+    """
+    if not entries:
+        return []
+
+    grouped: dict[tuple[str, str], list[dict]] = {}
+    for entry in entries:
+        key = (
+            entry.get("invoice_from") or "",
+            entry.get("invoice_to") or entry.get("date") or "",
+        )
+        grouped.setdefault(key, []).append(entry)
+
+    def _rank(e: dict) -> tuple[float, int]:
+        # Sort largest-non-zero first; on equal values, actual wins
+        # (is_estimated=False → 0 < 1 → sorts before estimate).
+        consumption = e.get("consumption") or 0
+        return (-float(consumption), 1 if e.get("is_estimated") else 0)
+
+    collapsed: list[dict] = []
+    for group in grouped.values():
+        if len(group) == 1:
+            collapsed.append(group[0])
+            continue
+        collapsed.append(sorted(group, key=_rank)[0])
+
+    collapsed.sort(key=lambda d: (d.get("invoice_to") or d.get("date") or ""))
+    return collapsed
+
+
 class MercuryAPI:
     """Mercury Energy API client wrapper."""
 
@@ -979,7 +1026,19 @@ class MercuryAPI:
             # Each entry in gas_monthly.daily_usage represents an INVOICE PERIOD
             # (typically one month) — name is misleading because pymercury reuses
             # ServiceUsage's daily_usage list regardless of the request interval.
-            monthly_history = list(getattr(gas_monthly, "daily_usage", []) or [])
+            #
+            # Mercury returns gas as parallel (estimate, actual) pairs — one
+            # entry per group per period, with one zero per pair. pymercury
+            # 1.1.3+ exposes consumption_periods (pre-collapsed); 1.1.2 only
+            # has the flat 20-entry daily_usage. Collapse locally when the
+            # newer property is unavailable so the importer never sees the
+            # zero-pair partner overwriting a real estimate.
+            consumption_periods = getattr(gas_monthly, "consumption_periods", None)
+            if consumption_periods is not None:
+                monthly_history = list(consumption_periods)
+            else:
+                raw_history = list(getattr(gas_monthly, "daily_usage", []) or [])
+                monthly_history = _collapse_gas_pairs(raw_history)
 
             _LOGGER.info(
                 "Mercury gas: %d monthly entries, %.2f kWh total, $%.2f total",

--- a/custom_components/mercury_co_nz/statistics.py
+++ b/custom_components/mercury_co_nz/statistics.py
@@ -35,7 +35,6 @@ from .const import (
     STATISTICS_FAILURE_NOTIFICATION_THRESHOLD,
     STATISTICS_GAS_CONSUMPTION_SUFFIX,
     STATISTICS_GAS_COST_SUFFIX,
-    STATISTICS_REIMPORT_DAYS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -420,11 +419,14 @@ class MercuryStatisticsImporter:
                 buckets.setdefault(slot, (hourly_kwh, hourly_cost))
                 slot += timedelta(hours=1)
 
-        # 4. Emit chronologically with cumulative sums; skip slots before cutoff.
+        # 4. Emit chronologically with cumulative sums; skip slots at or
+        #    before cutoff (the recorder's cumulative `sum` baseline already
+        #    accounts for them — re-adding their kwh inflates the most-recent
+        #    slot's sum on every coordinator cycle).
         energy_stats: list[StatisticData] = []
         cost_stats: list[StatisticData] = []
         for slot in sorted(buckets.keys()):
-            if slot.timestamp() < cutoff_ts:
+            if slot.timestamp() <= cutoff_ts:
                 continue
             kwh, cost_value = buckets[slot]
             energy_sum_start += kwh
@@ -549,9 +551,14 @@ class MercuryStatisticsImporter:
                 cost_meta["statistic_id"]
             )
 
-            cutoff_ts: float = (
-                last_ts_energy or 0.0
-            ) - STATISTICS_REIMPORT_DAYS * 86400
+            # Cutoff is the timestamp of the last entry already in the recorder.
+            # `_build_*_entries` filters out anchors at or before this so we
+            # never re-emit entries whose contribution is already in
+            # `last_sum_energy`. Without this guard, each coordinator cycle
+            # would re-add the most-recent entry's kwh on top of a baseline
+            # that already includes it, inflating its `sum` by N×kwh after N
+            # cycles (the cause of the v1.5.1 gas "164,220 kWh" bar).
+            cutoff_ts: float = last_ts_energy or 0.0
 
             if self._fuel_type == "gas":
                 energy_stats, cost_stats, null_skip_count = self._build_monthly_entries(

--- a/custom_components/mercury_co_nz/tests/test_gas_pipeline.py
+++ b/custom_components/mercury_co_nz/tests/test_gas_pipeline.py
@@ -22,6 +22,7 @@ from custom_components.mercury_co_nz.const import (
     STATISTICS_GAS_CONSUMPTION_SUFFIX,
     STATISTICS_GAS_COST_SUFFIX,
 )
+from custom_components.mercury_co_nz.mercury_api import _collapse_gas_pairs
 from custom_components.mercury_co_nz.statistics import MercuryStatisticsImporter
 
 
@@ -282,3 +283,199 @@ def test_gas_primary_icp_back_compat_store_key_unchanged() -> None:
         hass, "user@example.com", fuel_type="gas"
     )
     assert gas_primary._store.key == f"{DOMAIN}_statistics_gas_{gas_primary._email_hash}"
+
+
+# ----------------------------------------------------------------------------
+# v1.5.2 — _collapse_gas_pairs (Mercury parallel estimate/actual pair handling)
+# ----------------------------------------------------------------------------
+
+
+def _pair_record(
+    invoice_from: str,
+    invoice_to: str,
+    consumption: float,
+    cost: float,
+    is_estimated: bool,
+) -> dict:
+    """Build a pymercury 1.1.2-shaped record (one half of an estimate/actual pair)."""
+    return {
+        "date": invoice_to,
+        "consumption": consumption,
+        "cost": cost,
+        "free_power": False,
+        "invoice_from": invoice_from,
+        "invoice_to": invoice_to,
+        "is_estimated": is_estimated,
+        "read_type": "estimate" if is_estimated else "actual",
+    }
+
+
+def test_collapse_picks_actual_when_estimate_pair_is_zero() -> None:
+    """For 27 March (the user's reported anchor), Mercury returns
+    estimate=0/actual=460 — the collapse must pick the actual entry."""
+    pairs = [
+        _pair_record("2026-02-27", "2026-03-27", 0, 0, is_estimated=True),
+        _pair_record("2026-02-27", "2026-03-27", 460, 156.28, is_estimated=False),
+    ]
+    collapsed = _collapse_gas_pairs(pairs)
+    assert len(collapsed) == 1
+    assert collapsed[0]["consumption"] == 460
+    assert collapsed[0]["is_estimated"] is False
+
+
+def test_collapse_picks_estimate_when_actual_pair_is_zero() -> None:
+    """For 26 February in the user's data, Mercury returns
+    estimate=397/actual=0 — the v1.5.1 bucketize-overwrite bug dropped the
+    real value to zero. Collapse must keep the non-zero estimate."""
+    pairs = [
+        _pair_record("2026-01-31", "2026-02-26", 397, 139.20, is_estimated=True),
+        _pair_record("2026-01-31", "2026-02-26", 0, 0, is_estimated=False),
+    ]
+    collapsed = _collapse_gas_pairs(pairs)
+    assert len(collapsed) == 1
+    assert collapsed[0]["consumption"] == 397
+    assert collapsed[0]["is_estimated"] is True
+
+
+def test_collapse_full_year_real_shape_sums_to_total_usage() -> None:
+    """Captured-shape regression: 10 billing periods × 2 groups → 10 collapsed
+    entries summing to 4842 kWh (the user's real annual gas consumption)."""
+    pairs = [
+        # period: (invoice_from, invoice_to, est, act, real_value, tag)
+        _pair_record("2025-06-14", "2025-07-01",   0,   0.00, True),
+        _pair_record("2025-06-14", "2025-07-01", 324,  91.08, False),
+        _pair_record("2025-07-02", "2025-07-30", 517, 145.86, True),
+        _pair_record("2025-07-02", "2025-07-30",   0,   0.00, False),
+        _pair_record("2025-07-31", "2025-08-29",   0,   0.00, True),
+        _pair_record("2025-07-31", "2025-08-29", 539, 151.61, False),
+        _pair_record("2025-08-30", "2025-09-30", 571, 183.68, True),
+        _pair_record("2025-08-30", "2025-09-30",   0,   0.00, False),
+        _pair_record("2025-10-01", "2025-10-30",   0,   0.00, True),
+        _pair_record("2025-10-01", "2025-10-30", 635, 193.68, False),
+        _pair_record("2025-10-31", "2025-11-27",   0,   0.00, True),
+        _pair_record("2025-10-31", "2025-11-27", 463, 154.67, False),
+        _pair_record("2025-11-28", "2025-12-27", 493, 165.11, True),
+        _pair_record("2025-11-28", "2025-12-27",   0,   0.00, False),
+        _pair_record("2025-12-28", "2026-01-30",   0,   0.00, True),
+        _pair_record("2025-12-28", "2026-01-30", 443, 163.84, False),
+        _pair_record("2026-01-31", "2026-02-26", 397, 139.20, True),
+        _pair_record("2026-01-31", "2026-02-26",   0,   0.00, False),
+        _pair_record("2026-02-27", "2026-03-27",   0,   0.00, True),
+        _pair_record("2026-02-27", "2026-03-27", 460, 156.28, False),
+    ]
+    collapsed = _collapse_gas_pairs(pairs)
+    assert len(collapsed) == 10
+    assert sum(c["consumption"] for c in collapsed) == 4842
+    # Order is chronological by invoice_to.
+    assert [c["invoice_to"] for c in collapsed] == sorted(
+        c["invoice_to"] for c in collapsed
+    )
+
+
+def test_collapse_tie_break_prefers_actual() -> None:
+    """If Mercury ever returns equal non-zero values for both groups (a
+    reissued read), pick the actual."""
+    pairs = [
+        _pair_record("2026-01-01", "2026-01-31", 100, 30, is_estimated=True),
+        _pair_record("2026-01-01", "2026-01-31", 100, 30, is_estimated=False),
+    ]
+    collapsed = _collapse_gas_pairs(pairs)
+    assert len(collapsed) == 1
+    assert collapsed[0]["is_estimated"] is False
+
+
+def test_collapse_picks_larger_when_both_non_zero() -> None:
+    """Defensive: if Mercury sends both with different non-zero values,
+    pick the larger (likely the corrected/finalized read)."""
+    pairs = [
+        _pair_record("2026-01-01", "2026-01-31",  50, 15, is_estimated=True),
+        _pair_record("2026-01-01", "2026-01-31",  75, 22, is_estimated=False),
+    ]
+    collapsed = _collapse_gas_pairs(pairs)
+    assert len(collapsed) == 1
+    assert collapsed[0]["consumption"] == 75
+
+
+def test_collapse_passes_through_unpaired_records() -> None:
+    """Single-group payloads (no estimate/actual structure) are returned
+    chronologically, one entry per period."""
+    pairs = [
+        _pair_record("2026-02-01", "2026-02-28", 80, 20, is_estimated=False),
+        _pair_record("2026-01-01", "2026-01-31", 60, 15, is_estimated=False),
+    ]
+    collapsed = _collapse_gas_pairs(pairs)
+    assert len(collapsed) == 2
+    assert collapsed[0]["invoice_to"] == "2026-01-31"
+    assert collapsed[1]["invoice_to"] == "2026-02-28"
+
+
+def test_collapse_empty_input_returns_empty() -> None:
+    assert _collapse_gas_pairs([]) == []
+
+
+# ----------------------------------------------------------------------------
+# v1.5.2 — sum-baseline regression: most-recent imported entry must NOT be
+# re-emitted (caused 460 × N compounding for the 27 March gas dashboard bar)
+# ----------------------------------------------------------------------------
+
+
+def test_monthly_entries_skip_anchor_at_cutoff_to_prevent_compounding() -> None:
+    """Regression: when cutoff_ts equals the timestamp of an entry already
+    in the recorder, that entry MUST be skipped. `energy_sum_start` is the
+    recorder's cumulative sum *through* that anchor, so re-adding its kwh
+    would double-count and inflate by N×kwh after N coordinator cycles —
+    the v1.5.1 "164,220 kWh on 27 Mar" symptom."""
+    march_anchor = datetime(2026, 3, 26, 11, 0, 0, tzinfo=timezone.utc)
+    records = [
+        _record("2026-03-27T00:00:00+13:00", 460.0, 156.28),  # anchor == cutoff
+    ]
+    energy, _cost, skipped = MercuryStatisticsImporter._build_monthly_entries(
+        records,
+        energy_sum_start=2864.0,    # recorder's sum through March 27 (incl.)
+        cost_sum_start=900.0,
+        cutoff_ts=march_anchor.timestamp(),
+    )
+    assert skipped == 0  # null_skip only counts parse failures
+    assert energy == []  # no re-emission — would compound otherwise
+
+
+def test_monthly_entries_emit_only_strictly_newer_than_cutoff() -> None:
+    """Entries older than cutoff are skipped, equal-to-cutoff is skipped
+    (already-imported boundary), strictly-newer is emitted with sum
+    accumulating correctly from the carry-over."""
+    feb_anchor = datetime(2026, 2, 25, 11, 0, 0, tzinfo=timezone.utc)
+    records = [
+        _record("2026-02-26T00:00:00+13:00", 397.0, 139.20),  # at cutoff
+        _record("2026-03-27T00:00:00+13:00", 460.0, 156.28),  # > cutoff
+    ]
+    energy, _cost, skipped = MercuryStatisticsImporter._build_monthly_entries(
+        records,
+        energy_sum_start=2404.0,
+        cost_sum_start=750.0,
+        cutoff_ts=feb_anchor.timestamp(),
+    )
+    assert skipped == 0
+    assert len(energy) == 1
+    assert energy[0]["state"] == 460.0
+    assert energy[0]["sum"] == 2404.0 + 460.0
+
+
+def test_hourly_entries_skip_slot_at_cutoff_to_prevent_compounding() -> None:
+    """Same regression as monthly, for the electricity hourly path. A slot
+    whose timestamp equals cutoff_ts is already in the recorder's sum
+    baseline; re-emitting it would compound by `kwh` per coordinator
+    cycle until the slot exits the (formerly 3-day) window."""
+    last_slot = datetime(2026, 4, 28, 10, 0, 0, tzinfo=timezone.utc)
+    daily_records = []
+    hourly_records = [
+        {"datetime": "2026-04-28T22:00:00+12:00", "consumption": 1.5, "cost": 0.40},  # NZ-local 22:00 == 10:00 UTC
+    ]
+    energy, _cost, skipped = MercuryStatisticsImporter._build_hourly_entries(
+        daily_records,
+        hourly_records,
+        energy_sum_start=1234.5,
+        cost_sum_start=450.0,
+        cutoff_ts=last_slot.timestamp(),
+    )
+    assert skipped == 0
+    assert energy == []  # no re-emission

--- a/custom_components/mercury_co_nz/tests/test_statistics.py
+++ b/custom_components/mercury_co_nz/tests/test_statistics.py
@@ -146,7 +146,12 @@ def test_hourly_split_dst_start_23_hour_day() -> None:
 
 
 def test_hourly_split_skips_already_imported() -> None:
-    """Strict less-than cutoff: entries at-or-after cutoff pass; entries before are skipped."""
+    """Cutoff is the timestamp of the last imported slot; that slot AND
+    everything before it are already represented in the recorder's
+    cumulative `sum` baseline, so emitting them would compound.
+
+    v1.5.2 fix: the at-cutoff slot is excluded along with pre-cutoff slots.
+    """
     records = [
         {"date": "2026-05-14T00:00:00", "consumption": 24.0, "cost": 12.0},
         {"date": "2026-05-15T00:00:00", "consumption": 24.0, "cost": 12.0},
@@ -156,10 +161,11 @@ def test_hourly_split_skips_already_imported() -> None:
     energy, _cost, _ = MercuryStatisticsImporter._build_hourly_entries(
         records, [], 0.0, 0.0, cutoff
     )
-    # The 24 entries from 2026-05-14 are all strictly before cutoff -> skipped.
-    # The 24 entries from 2026-05-15 start at exactly cutoff -> included (not strictly <).
-    assert len(energy) == 24
-    assert energy[0]["start"] >= datetime(2026, 5, 14, 12, 0, tzinfo=timezone.utc)
+    # All 2026-05-14 hours: strictly before cutoff → skipped.
+    # 2026-05-15 hour at exactly cutoff: skipped (already imported).
+    # Remaining 23 hours of 2026-05-15: emitted.
+    assert len(energy) == 23
+    assert energy[0]["start"] > datetime(2026, 5, 14, 12, 0, tzinfo=timezone.utc)
 
 
 def test_hourly_split_counts_null_records() -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 # These are automatically installed by Home Assistant from manifest.json
 
 aiohttp>=3.8.0
-mercury-co-nz-api>=1.1.2
+mercury-co-nz-api>=1.1.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ homeassistant>=2025.11.0
 # Core dependencies
 aiohttp>=3.8.0
 voluptuous>=0.13.0
-mercury-co-nz-api>=1.1.2
+mercury-co-nz-api>=1.1.3
 
 # Development tools
 black>=22.0.0


### PR DESCRIPTION
## Summary

Two compounding defects produced the bizarre **164,220 kWh** value users saw in the HA Energy Dashboard for 27 March gas. pymercury 1.1.2 itself returns correct values; both bugs live downstream in the integration.

### Defect 1 — Mercury parallel-pair overwrite
Mercury returns gas as parallel `(estimate, actual)` pairs — one entry per group per billing period, with one zero per pair. `_build_monthly_entries` bucketized by anchor with `dict[anchor] = (kwh, cost)`, so the second-written entry **clobbered** the first. For one user this silently dropped ~1978 kWh of consumption history (the months Mercury sorted zero last).

### Defect 2 — Cumulative-sum baseline compounded
`cutoff_ts = last_ts − 3 days` kept the most-recent imported entry inside the re-emit window. `energy_sum_start = last_sum_energy` is the recorder's cumulative sum **through and including** that entry. Re-emitting added its `kwh` on top of a baseline that already included it. Each coordinator cycle inflated the most-recent entry's `sum` by another `kwh`:

- `kwh = 460` (user's actual 27 Mar consumption)
- 5-min coordinator cycles
- ~357 cycles (~30 hours) → `460 × 358 ≈ 164,220` ← matches the reported number

Same pattern existed in `_build_hourly_entries` (electricity).

## Changes

- `mercury_api.py`: new `_collapse_gas_pairs()` helper. `get_gas_usage_data` prefers `ServiceUsage.consumption_periods` (pymercury 1.1.3) and falls back to local pair-collapse defensively. Pick the larger non-zero entry per `(invoice_from, invoice_to)` window; tie-break to actual.
- `statistics.py`: `cutoff_ts` is now the timestamp of the last imported entry (was `last_ts − 3 days`). `_build_hourly_entries` filter `< cutoff_ts` → `<= cutoff_ts` so both paths consistently skip already-imported entries. `STATISTICS_REIMPORT_DAYS` removed.
- `const.py`: drop `STATISTICS_REIMPORT_DAYS`.
- `manifest.json`: requirements `mercury-co-nz-api>=1.1.2` → `>=1.1.3` (consumption_periods); version `1.5.1` → `1.5.2`.
- `requirements.txt` / `requirements_dev.txt`: aligned to `>=1.1.3`.

## Tests

103 pass (+9 new):
- `test_collapse_picks_actual_when_estimate_pair_is_zero` (27 Mar = 460/actual)
- `test_collapse_picks_estimate_when_actual_pair_is_zero` (26 Feb = 397/estimate — the previously-lost value)
- `test_collapse_full_year_real_shape_sums_to_total_usage` — captured-shape regression: 10 periods × 2 groups → 10 collapsed entries summing to **4842 kWh** (user's real annual gas use)
- `test_collapse_tie_break_prefers_actual` / `test_collapse_picks_larger_when_both_non_zero` / `test_collapse_passes_through_unpaired_records` / `test_collapse_empty_input_returns_empty`
- `test_monthly_entries_skip_anchor_at_cutoff_to_prevent_compounding` — direct regression for the 460×N compounding
- `test_hourly_split_skips_already_imported` updated to assert at-cutoff exclusion (was strict `<`)

## Migration note for existing users

The fix prevents **new** compounding but the recorder is authoritative for rows already written. Users with inflated ghost rows in their statistics DB will need to clear them manually:

> **Developer Tools → Statistics → ⋯ menu on `mercury_co_nz:..._gas_consumption` → Clear statistics**

Then let the integration re-import on the next coordinator tick.

## Test plan

- [ ] Test HA instance with a gas service shows correct daily/monthly bars for 27 Mar after upgrade
- [ ] No regression on electricity hourly statistics (existing test suite covers; verified locally)
- [ ] HACS shows v1.5.2 update prompt
- [ ] After update + clear_statistics, `pip show mercury-co-nz-api` reports 1.1.3 and `consumption_periods` produces 10 collapsed periods summing to upstream `total_usage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)