### PR TITLE
feat: v1.6.0 — gas monthly summary card (bar chart, estimate vs actual)

### DIFF
--- a/.claude/PRPs/issues/investigation-20260428T105734Z-v152-still-compounding.md
+++ b/.claude/PRPs/issues/investigation-20260428T105734Z-v152-still-compounding.md
@@ -1,0 +1,208 @@
+# Investigation: gas dashboard 166,980 kWh on v1.5.2 — still compounding?
+
+**Issue**: free-form (no GitHub issue)
+**Type**: BUG (likely deployment, not code)
+**Investigated**: 2026-04-28T10:57:34Z
+
+### Assessment
+
+| Metric     | Value  | Reasoning |
+| ---------- | ------ | --------- |
+| Severity   | MEDIUM | Wrong number on a single dashboard row; user already has the v1.5.2 code on disk and one full HA restart is the recovery. No data loss; no widening of impact. |
+| Complexity | LOW    | Almost certainly a HACS-update-without-restart issue — zero new code changes needed. If a real code regression is found, a single-test integration scenario reproduces it. |
+| Confidence | HIGH (deployment hypothesis); MEDIUM (rules out everything else) | Two parallel codebase agents traced every gas-statistic write path on `main@57a6122`. The math `(166,980 − 164,220) / 460 = exactly 6 cycles` matches a 30-minute window of v1.5.1 bytecode running while v1.5.2 files were on disk. Hypothesis 6 alternatives (anchor mismatch, race, multi-writer, tz handling) were each ruled out with file:line evidence. |
+
+---
+
+## Problem Statement
+
+User on v1.5.2 (deployed via HACS) reports the gas energy dashboard for 27 March 2026 is still rising — `164,220 kWh → 166,980 kWh`. The v1.5.2 fix changed `cutoff_ts = last_ts_energy` (was `last_ts − 3 days`) so the most-recent imported entry is excluded from re-emission and the `sum` stops compounding. The fact that the value is rising means *something* is still re-emitting March 27 with an ever-larger `sum`.
+
+---
+
+## Analysis
+
+### The arithmetic identity is too clean to be accidental
+
+```
+166,980 − 164,220 = 2,760
+2,760 / 460        = 6.000 (exactly)
+460                = user's actual 27 March consumption (pymercury consumption_periods)
+```
+
+**Six** additional compounding cycles occurred between the v1.5.1 baseline and the user's v1.5.2 reading. At the integration's 5-min coordinator interval (`DEFAULT_SCAN_INTERVAL = 5`, `const.py:29`), six cycles is a 30-minute window.
+
+### Why this is almost certainly HACS-update-without-restart
+
+HACS downloads the new `custom_components/mercury_co_nz/*.py` files to disk but **does not** hot-swap the running Python modules. The HA process keeps executing the v1.5.1 bytecode it imported at startup until HA is fully restarted. During the gap between "HACS finished writing files" and "HA was restarted", the still-running v1.5.1 code continues with its broken cutoff:
+
+```python
+# v1.5.1 (still running in memory after HACS file write)
+cutoff_ts: float = (last_ts_energy or 0.0) - STATISTICS_REIMPORT_DAYS * 86400  # last_ts - 3 days
+```
+
+Each 5-min tick:
+1. Reads `last_ts_energy = T_march27`, `last_sum_energy = 164,220` (then `164,680`, `165,140`, …) from recorder.
+2. Computes `cutoff_ts = T_march27 − 259200`.
+3. March 27's anchor `> cutoff_ts` → IS included in re-emission.
+4. `energy_running = last_sum + 460` written back to the same row → recorder upserts, sum grows by 460.
+
+Six ticks × 460 kWh/tick = +2,760 kWh = the observed delta.
+
+After the user restarts HA, v1.5.2 bytecode loads. `cutoff_ts = T_march27`. Filter `anchor > T_march27` excludes March 27. The `sum` of the March 27 row is **frozen at 166,980** until manually corrected via HA Developer Tools → Statistics.
+
+### Hypotheses ruled out (with file:line evidence)
+
+| # | Hypothesis | Verdict | Evidence |
+|---|---|---|---|
+| 1 | Anchor mismatch — `consumption_periods` produces a different `invoice_to` shape from `daily_usage` | RULED OUT | `pymercury/api/models/base.py:202-209` passes `invoiceTo` through verbatim from Mercury's API into both `daily_usage` and (via group-by) `consumption_periods`. `_parse_invoice_end_utc` (`statistics.py:206-232`) yields identical UTC anchor `1774522800.0` for `"2026-03-27"`, `"2026-03-27T00:00:00"`, and `"2026-03-27T00:00:00+13:00"`. |
+| 2 | Cutoff reads from a different `statistic_id` than v1.5.1 wrote | RULED OUT | `_build_metadata` (`statistics.py:149-184`) formula is byte-identical to v1.5.1 for the gas/primary case; `id_prefix` lock is persisted via Store. |
+| 3 | `async_add_external_statistics` appends instead of upserting | RULED OUT | HA recorder `_import_statistics_with_session` (`venv/.../recorder/statistics.py:2734-2754`) calls `_statistics_exists(metadata_id, start_ts)` then `_update_statistics` on hit, `_insert_statistics` on miss. Genuine upsert keyed on `(metadata_id, start_ts)`. Same `start_ts` always overwrites. |
+| 4 | Naive vs offset-aware tz handling silently shifts `start_ts` | RULED OUT | HA `_async_import_statistics` raises `HomeAssistantError` for naive datetimes; `_parse_invoice_end_utc` returns `tzinfo=timezone.utc`. Stored `start_ts = anchor.timestamp() = 1774522800.0`. |
+| 5 | `_async_get_last_imported` returns `None` for `last_start` | RULED OUT | HA `_build_sum_stats` (`venv/.../recorder/statistics.py:_build_sum_stats`) populates `start` as the raw `start_ts` float. `get_last_statistics(n=1, ...)` orders `start_ts.desc()`. The most-recent row's `start` is always the float Unix timestamp. |
+| 6 | Second writer (e.g., the v2.0.0 multi-ICP per-ICP importer) | RULED OUT | `coordinator.py:109-110` instantiates exactly one `MercuryStatisticsImporter(fuel_type="gas")` on `main@57a6122`. The v2.0.0 multi-importer commit lives only on `fix/multi-icp-v200-phases-2-5`. |
+| 7 | Cost statistic compounding bleeds into the energy bar | RULED OUT | Cost is NZD-denominated, separate `statistic_id`; HA Energy Dashboard reads gas energy from the energy series only. |
+| 8 | Recorder write/read race on the 5-min cadence | RULED OUT | `async_add_external_statistics` queues `ImportStatisticsTask` on the recorder's single-threaded executor; `get_last_statistics` runs on the same executor as a follow-up future. FIFO ordering guaranteed. |
+| 9 | DST boundary | RULED OUT | NZ DST ends 2026-04-05; March 27 is firmly NZDT (+13). `ZoneInfo("Pacific/Auckland")` resolves correctly. |
+| 10 | The fix didn't actually land at HEAD `57a6122` | RULED OUT | `git show 57a6122` confirms `cutoff_ts = last_ts_energy or 0.0` and `_build_hourly_entries` filter `<= cutoff_ts`. Both changes are present. 103 tests pass on main; 116 on the cherry-picked v2.0.0 branch. |
+
+### Affected Files
+
+No code changes required — the fix is correct. The remediation is operational:
+
+| Action | Where | Description |
+|---|---|---|
+| Fully restart HA | Settings → System → Restart | Forces Python to re-import the v1.5.2 modules from disk |
+| Clear inflated stat row | Developer Tools → Statistics → search `mercury_co_nz` gas → **Fix Issues** OR ⋯ menu → **Clear statistics** | The 166,980 frozen value lives in the recorder DB; v1.5.2 will not re-emit at that anchor |
+
+### Integration Points
+
+- `coordinator.py:243-251` — invokes `_gas_statistics.async_update(combined_data)` on every 5-min tick.
+- `statistics.py:587-588` — sole `async_add_external_statistics` call site for gas.
+- `statistics.py:561` (HEAD `57a6122`) — `cutoff_ts: float = last_ts_energy or 0.0`. Verify this line in the user's `/config/custom_components/mercury_co_nz/statistics.py` after restart.
+
+### Git History
+
+- `57a6122` (2026-04-28) — v1.5.2 fix landed, files written to GitHub release.
+- `ddc4049` (2026-04-28) — v1.5.1 (pymercury 1.1.2 pin).
+- The v1.5.1 → v1.5.2 window is small; the user almost certainly upgraded via HACS within hours of v1.5.2's GitHub release.
+
+---
+
+## Implementation Plan
+
+### Step 1 — Verify v1.5.2 is actually loaded (not just on disk)
+
+User runs in HA's Terminal & SSH add-on (or equivalent):
+
+```bash
+cat /config/custom_components/mercury_co_nz/manifest.json | python3 -c "import sys,json; d=json.load(sys.stdin); print('version:', d['version']); print('requires:', d['requirements'])"
+```
+
+Expect: `version: 1.5.2`, `requires: ['aiohttp>=3.8.0', 'mercury-co-nz-api>=1.1.3']`.
+
+If version reads `1.5.1`, the HACS update never landed — re-run the HACS update.
+
+### Step 2 — Confirm v1.5.1 bytecode is no longer running
+
+```bash
+grep -r "STATISTICS_REIMPORT_DAYS" /config/custom_components/mercury_co_nz/
+```
+
+Expect: **no matches** (the constant was removed in v1.5.2). If it's still there, v1.5.1 files are on disk too — HACS may have left both in place, force-clean and re-install.
+
+### Step 3 — Full HA restart
+
+**Settings → System → Restart Home Assistant** (NOT a config-entry reload — that doesn't always re-import custom_components Python modules from disk; a full HA process restart does).
+
+### Step 4 — Confirm v1.5.2 is now active
+
+After restart, watch HA logs for:
+
+```
+Mercury statistics: nothing to import (cutoff_ts=1774522800.0, null_skipped=0)
+```
+
+(Expected at DEBUG level after the first post-restart coordinator tick. Enable debug logging via `Settings → System → Logs → Customize logging` for `custom_components.mercury_co_nz` if needed.)
+
+If you see `Mercury statistics: imported 1 hourly entries (energy + cost), skipped 0 null records` for gas every 5 min, **the fix is not active** — go back to Step 1.
+
+### Step 5 — Clear the inflated 166,980 row
+
+**Developer Tools → Statistics**, search `mercury_co_nz`, find the gas energy statistic (id ends in `_gas_consumption`).
+
+Two options:
+
+**Option A (clean slate, safer)**: Click **⋯ → Clear statistics**, then wait one coordinator tick. The integration will see an empty recorder, set `last_ts_energy = None`, `last_sum_energy = 0.0`, and re-import the entire gas history from genesis with correct cumulative sums.
+
+**Option B (surgical, faster)**: Use **Fix Issues** to spot-edit the bad row to a sensible value if HA exposes an editor. Less reliable; depends on HA version.
+
+After Step 5, the dashboard should show `460 kWh` for 27 March (the actual consumption from pymercury `consumption_periods`).
+
+---
+
+## Patterns to Follow
+
+This is operational guidance — no code patterns to mirror.
+
+---
+
+## Edge Cases & Risks
+
+| Risk / Edge Case | Mitigation |
+|---|---|
+| User restarts but pymercury 1.1.3 didn't get installed (HA's pip cache has 1.1.2) | After restart, `pip show mercury-co-nz-api` in the HA container should report `1.1.3`. If `1.1.2`, force HA's pip to re-resolve via `pip install --upgrade mercury-co-nz-api`, then restart again. v1.5.2 is **defensive** against this case (`_collapse_gas_pairs` fallback in `mercury_api.py`), so the cutoff fix works regardless of pymercury version. |
+| Clear-statistics removes ALL gas history, not just the bad row | Yes — Option A is intentionally a clean slate. The integration re-imports the whole 10-period series from pymercury on the next tick. Correct values land within ~5 min. |
+| User had multiple inflated rows (not just March 27) from earlier v1.5.1 cycles | `_build_monthly_entries` only re-emits anchors `> cutoff_ts`. Once the most-recent anchor is March 27 (correctly stored), February and earlier are NEVER re-emitted, so any inflation from older v1.5.1 cycles is also frozen. Clearing the gas series via Step 5 wipes ALL of them and re-imports clean. |
+| Future bug: the `_gas_statistics` importer instance is held in coordinator state across HA restart via Store | `Store` only persists `_id_prefix` (the email-hash lock); the running `MercuryStatisticsImporter` object is freshly instantiated each HA startup. No stale-state-across-restart risk. |
+
+---
+
+## Validation
+
+### Automated Checks
+
+```bash
+cd /var/www/personal/home-assistant-mercury-co-nz
+.venv/bin/python -m pytest custom_components/mercury_co_nz/tests/ --no-cov -q
+```
+
+Expect 103/103 passing on `main@57a6122`. Already verified.
+
+### Manual Verification (the user's HA instance)
+
+1. Step 1 confirms `1.5.2` on disk.
+2. Step 2 confirms no v1.5.1 leftovers.
+3. Step 3 fully restarts HA.
+4. Step 4 confirms log says `nothing to import` for gas after one tick.
+5. Step 5 clears the gas series.
+6. After ~5 min: dashboard shows `460 kWh` for 27 March (and proper values for prior months — `397 kWh` for 26 February, etc.).
+
+---
+
+## Scope Boundaries
+
+**IN SCOPE:**
+
+- Operational remediation (restart + clear stale stats).
+- Verifying the v1.5.2 fix is correctly deployed.
+
+**OUT OF SCOPE:**
+
+- New code changes — the fix is correct as shipped. The regression is a known-class HACS deployment issue, not a code bug.
+- A test that simulates "HACS file swap mid-process" — Python doesn't support that; HA can't realistically defend against partial-deployment compounding without checksumming its own bytecode against disk on every tick.
+- Adding HACS auto-restart — that's a HACS-level setting on the user's side, not something this integration controls.
+- Documenting the post-update restart in the README — likely worth doing as a follow-up but not a blocker for this artifact.
+
+---
+
+## Metadata
+
+- **Investigated by**: Claude
+- **Timestamp**: 2026-04-28T10:57:34Z
+- **Artifact**: `.claude/PRPs/issues/investigation-20260428T105734Z-v152-still-compounding.md`
+- **Branch at investigation**: `main` (HEAD `57a6122`, v1.5.2)
+- **Related**:
+  - Prior investigation: `/var/www/personal/pymercury/.claude/PRPs/issues/investigation-gas-164220-ha-recurrence.md` (the 164,220 root cause).
+  - Shipped fix: PR #20 (squash-merged as `57a6122`), released as v1.5.2.
+- **Confidence**: HIGH for the HACS-update-no-restart hypothesis (math + ruled-out alternatives). MEDIUM that this fully explains the user's observation — small residual chance that `pip` didn't install pymercury 1.1.3 and the user is on an unexpected version. Step 1 + Step 4 verify both at once.

--- a/.claude/PRPs/plans/gas-monthly-summary-card.plan.md
+++ b/.claude/PRPs/plans/gas-monthly-summary-card.plan.md
@@ -1,0 +1,767 @@
+# Feature: Gas Monthly Summary Card (bar chart with month nav)
+
+## Summary
+
+Build a new LitElement Lovelace card — `mercury-gas-monthly-summary-card` — that mirrors the **monthly mode of the existing `energy-usage-card.js`** (the bar-chart with prev/next pagination), but reads from gas-side data and renders each bar with a color that reflects its `is_estimated` flag (yellow `rgb(255, 240, 0)` for actual readings, gray `#727272` for estimated). Also adds the missing Python plumbing — currently `gas_monthly_usage_history` lives in `coordinator.data` but is **not exposed on any sensor entity**, so a new chart-capable gas sensor type must be added so the card has an entity to read.
+
+## User Story
+
+As a Mercury Energy NZ customer with both electricity and gas
+I want a monthly bar-chart dashboard widget for gas consumption with the same UX as the existing electricity usage card
+So that I can see my month-by-month gas usage and immediately tell which periods are actual meter reads vs Mercury estimates.
+
+## Problem Statement
+
+The integration already exposes a beautiful electricity bar-chart card (`energy-usage-card.js`, monthly mode) reading `entity.attributes.monthly_usage_history`. There is **no equivalent for gas**: `gas_monthly_usage_history` is computed (post-v1.5.2 via pymercury 1.1.3 `consumption_periods` or local `_collapse_gas_pairs`), pushed into `coordinator.data` with `gas_` prefix, and consumed by the statistics importer for the Energy Dashboard — but never surfaced as a sensor `extra_state_attributes` entry, so frontend cards cannot read it. Additionally, no card in this codebase visually distinguishes estimated vs actual reads, even though gas billing pairs include both.
+
+## Solution Statement
+
+Two coordinated changes:
+
+1. **Python: expose gas chart data on a sensor.** Add a new `gas_monthly_usage` sensor type to `SENSOR_TYPES` (kWh-denominated total_usage scalar), and extend `MercurySensor.extra_state_attributes` to populate `gas_monthly_usage_history` (the pre-collapsed per-period list including `is_estimated` and `read_type`) on this new sensor. Mirror the existing electricity chart pattern at `sensor.py:267-321`.
+2. **JS: clone & specialize the bar-chart card.** Create `gas-monthly-summary-card.js` extending the same LitElement / `mercuryLitCore` mixin pattern as `energy-usage-card.js`. Strip down to monthly-only (no period-tab switcher needed; gas only has monthly data). Read `entity.attributes.gas_monthly_usage_history`. Use Chart.js's per-bar `backgroundColor`/`borderColor` array support to colorize each bar based on `entry.is_estimated`. Register the new file in `ALLOWED_JS_FILES` (`__init__.py`) and `JSMODULES` (`const.py`) so it loads via `frontend/__init__.py`.
+
+## Metadata
+
+| Field            | Value                                                                                                              |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Type             | NEW_CAPABILITY                                                                                                     |
+| Complexity       | MEDIUM                                                                                                             |
+| Systems Affected | sensor.py (new sensor type + chart attributes), const.py (sensor type + JSMODULES), __init__.py (ALLOWED_JS_FILES), new gas-monthly-summary-card.js |
+| Dependencies     | LitElement 3.1.0 (already loaded), Chart.js 4.5.0 (already loaded via CDN in core.js), pymercury>=1.1.3 (already pinned in manifest)              |
+| Estimated Tasks  | 7                                                                                                                  |
+
+---
+
+## UX Design
+
+### Before State
+```
+╔═══════════════════════════════════════════════════════════════════════════════╗
+║                              BEFORE STATE                                      ║
+╠═══════════════════════════════════════════════════════════════════════════════╣
+║                                                                                ║
+║  USER's Lovelace dashboard:                                                    ║
+║                                                                                ║
+║   ┌──────────────────────────────────────────────────────┐                     ║
+║   │ Mercury Energy Usage Card (electricity only)         │                     ║
+║   │  [Hourly] [Daily] [Monthly]                          │                     ║
+║   │  ┌────────────────────────────────────┐              │                     ║
+║   │  │  ▓ ▓ ▓ ▓ ▓ ▓  (yellow bars)        │              │                     ║
+║   │  │ Jan Feb Mar Apr May Jun            │              │                     ║
+║   │  └────────────────────────────────────┘              │                     ║
+║   │   <  1 Mar – 27 Mar  >                               │                     ║
+║   └──────────────────────────────────────────────────────┘                     ║
+║                                                                                ║
+║   ┌──────────────────────────────────────────────────────┐                     ║
+║   │ HA Energy Dashboard "Gas" section                    │                     ║
+║   │  bars-only, no nav, no estimate/actual tag           │                     ║
+║   └──────────────────────────────────────────────────────┘                     ║
+║                                                                                ║
+║  USER_FLOW: Electricity has rich chart card. Gas only appears as an Energy     ║
+║   Dashboard summary bar — no in-card month nav, no estimate/actual indicator,  ║
+║   no per-period cost tooltip.                                                  ║
+║  PAIN_POINT: User cannot see gas history with the same depth as electricity.   ║
+║   Cannot tell at a glance whether the monthly value was a real meter read or  ║
+║   an estimate.                                                                 ║
+║  DATA_FLOW: gas_monthly_usage_history → combined_data → statistics importer    ║
+║   ONLY. Never reaches sensor.extra_state_attributes, so no JS card can read it.║
+║                                                                                ║
+╚═══════════════════════════════════════════════════════════════════════════════╝
+```
+
+### After State
+```
+╔═══════════════════════════════════════════════════════════════════════════════╗
+║                               AFTER STATE                                      ║
+╠═══════════════════════════════════════════════════════════════════════════════╣
+║                                                                                ║
+║  USER's Lovelace dashboard:                                                    ║
+║                                                                                ║
+║   ┌──────────────────────────────────────────────────────┐                     ║
+║   │ Mercury Energy Usage Card (electricity)              │                     ║
+║   │  [Hourly] [Daily] [Monthly]   ▓ ▓ ▓ ▓ ▓ ▓            │                     ║
+║   └──────────────────────────────────────────────────────┘                     ║
+║                                                                                ║
+║   ┌──────────────────────────────────────────────────────┐  ◄── NEW CARD       ║
+║   │ Mercury Gas Monthly Summary Card                     │                     ║
+║   │  ┌────────────────────────────────────────┐          │                     ║
+║   │  │  ░ ▓ ░ ▓ ░ ░ ▓ ░ ▓ ░  (mixed colors)   │          │                     ║
+║   │  │ Jul Jul Aug Sep Oct Nov Dec Jan Feb Mar│          │                     ║
+║   │  │  est act est act est est act est act est│          │                     ║
+║   │  └────────────────────────────────────────┘          │                     ║
+║   │   <  27 Feb – 27 Mar  >                              │                     ║
+║   │   ● Actual  ○ Estimated   $156.28 | 460 kWh          │                     ║
+║   └──────────────────────────────────────────────────────┘                     ║
+║                                                                                ║
+║   ▓ = yellow rgb(255,240,0) = actual meter read                                ║
+║   ░ = gray  #727272         = Mercury estimate                                 ║
+║                                                                                ║
+║  USER_FLOW: User adds card via Lovelace UI (resource auto-registers via HACS); ║
+║   sets `entity: sensor.mercury_nz_gas_monthly_usage`; chart renders ~10 bars   ║
+║   one per billing period; clicking a bar shows the period's invoice range +   ║
+║   $cost + kWh; prev/next arrows page back through history.                    ║
+║  VALUE_ADD: Same depth of insight as electricity card. Visual estimate/actual ║
+║   indicator (the first time this distinction is rendered anywhere in the     ║
+║   integration's UI).                                                          ║
+║  DATA_FLOW: gas_monthly.consumption_periods (pymercury 1.1.3) → coordinator   ║
+║   gas_ prefix → sensor.gas_monthly_usage.extra_state_attributes               ║
+║   .gas_monthly_usage_history → card reads via hass.states[entity_id]          ║
+║   → Chart.js renders with per-bar backgroundColor array.                      ║
+║                                                                                ║
+╚═══════════════════════════════════════════════════════════════════════════════╝
+```
+
+### Interaction Changes
+
+| Location                                             | Before                                    | After                                                                                    | User Impact                                                                            |
+| ---------------------------------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `sensor.mercury_nz_gas_monthly_usage`                | Does not exist                            | New sensor with kWh state and `gas_monthly_usage_history` attribute                      | Gas data becomes a first-class HA entity — usable in any card, automation, template    |
+| Lovelace dashboard config UI                         | Only "Mercury Energy Usage Card" choice   | Adds "Mercury Gas Monthly Summary Card" in the custom-card picker                        | User can drop the card in via the UI                                                   |
+| Card bar appearance                                  | (no card)                                 | Yellow bars for actual periods, gray bars for estimated periods                          | Visual call-out of which months Mercury actually read the meter vs estimated           |
+
+---
+
+## Mandatory Reading
+
+**CRITICAL: Implementation agent MUST read these files before starting any task:**
+
+| Priority | File                                                                              | Lines        | Why Read This                                                                                                     |
+| -------- | --------------------------------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------- |
+| P0       | `custom_components/mercury_co_nz/energy-usage-card.js`                            | 1-1400       | THE mirror target — clone its monthly mode, navigation, click-to-select, Chart.js setup                          |
+| P0       | `custom_components/mercury_co_nz/sensor.py`                                       | 245-340      | The `extra_state_attributes` pattern — chart data is gated on a sensor whitelist (CHART_DATA_SENSORS)            |
+| P0       | `custom_components/mercury_co_nz/const.py`                                        | 18-22, 33-50, 167-172 | JSMODULES list, SENSOR_TYPES dict shape, the existing `bill_gas_amount` entry as a sample gas sensor          |
+| P1       | `custom_components/mercury_co_nz/__init__.py`                                     | 23-58        | `ALLOWED_JS_FILES` whitelist + `MercuryStaticView` URL routing pattern                                           |
+| P1       | `custom_components/mercury_co_nz/core.js`                                         | 1-430        | `mercuryLitCore` mixin — what `initializeBase()` provides (CHART_COLORS, theme detection, `_loadChartJS`, etc.) |
+| P1       | `custom_components/mercury_co_nz/styles.js`                                       | 584-614      | `mercuryChartStyles` (combined export for chart cards) and `mercuryColors` palette including SECONDARY_GRAY      |
+| P1       | `custom_components/mercury_co_nz/mercury_api.py`                                  | 977-1059     | `get_gas_usage_data()` — confirms what's in `gas_monthly_usage_history`, including the consumption_periods path  |
+| P1       | `custom_components/mercury_co_nz/coordinator.py`                                  | 169-176      | The `gas_` prefix loop that creates `combined_data["gas_monthly_usage_history"]`                                 |
+| P2       | `custom_components/mercury_co_nz/energy-weekly-summary-card.js`                   | 1-200        | Reference for stripped-down chart card (single period mode) — but our new card mirrors usage-card more closely  |
+| P2       | `custom_components/mercury_co_nz/frontend/__init__.py`                            | 60-110       | How `JSMODULES` entries become Lovelace resources (`async_create_item`)                                          |
+| P2       | `/var/www/personal/pymercury/pymercury/api/models/base.py`                        | 197-287      | Authoritative `daily_usage` shape (8 keys incl. `is_estimated`) and `consumption_periods` property               |
+
+**External Documentation:**
+
+| Source                                                                                                              | Section                                | Why Needed                                                                                            |
+| ------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| [Chart.js v4.5 docs](https://www.chartjs.org/docs/4.5.0/charts/bar.html#data-structure)                             | "Data Structure" / "Bar Chart"         | Confirm per-bar coloring via `backgroundColor: [color1, color2, ...]` array (one entry per data point) |
+| [Chart.js v4.5 dataset config](https://www.chartjs.org/docs/4.5.0/general/colors.html)                              | "Per-bar colors"                       | Same — used to vary actual/estimate                                                                    |
+| [LitElement 3.1.0 docs](https://lit.dev/docs/v3/components/lifecycle/#updated)                                     | "updated" lifecycle                    | Pattern already used in `energy-usage-card.js` for chart re-rendering on hass updates                 |
+
+(No new external dependencies — Chart.js is loaded from CDN by `core.js:_loadChartJS` and LitElement is imported via the same `unpkg.com/lit@3.1.0/index.js?module` URL all existing cards use.)
+
+---
+
+## Patterns to Mirror
+
+**SENSOR_TYPES_ENTRY:**
+```python
+# SOURCE: custom_components/mercury_co_nz/const.py:167-173
+# COPY THIS PATTERN (gas already has bill_gas_amount; mirror the shape):
+"bill_gas_amount": {
+    "name": "Gas Amount",
+    "unit": "$",
+    "icon": "mdi:fire",
+    "device_class": "monetary",
+    "state_class": "total",
+},
+```
+
+**CHART_DATA_SENSORS_PATTERN:**
+```python
+# SOURCE: custom_components/mercury_co_nz/sensor.py:255-267
+# COPY THIS PATTERN — and add the new gas sensor to it:
+CHART_DATA_SENSORS = [
+    "energy_usage",      # Main energy usage sensor - primary chart sensor
+    "total_usage",       # Total usage sensor
+    "current_bill"       # Current bill sensor
+]
+
+if self._sensor_type in CHART_DATA_SENSORS:
+    # ... daily/hourly/monthly_usage_history population ...
+```
+
+**MONTHLY_USAGE_HISTORY_ATTRIBUTE_BLOCK:**
+```python
+# SOURCE: custom_components/mercury_co_nz/sensor.py:317-321
+# COPY THIS EXACT PATTERN for the gas variant:
+if "monthly_usage_history" in self.coordinator.data:
+    monthly_history = self.coordinator.data["monthly_usage_history"]
+    attributes["monthly_usage_history"] = monthly_history
+    attributes["monthly_data_points"] = len(monthly_history)
+```
+
+**JSMODULES_REGISTRATION:**
+```python
+# SOURCE: custom_components/mercury_co_nz/const.py:18-22
+# COPY THIS PATTERN — append the new card:
+JSMODULES: Final[list[dict[str, str]]] = [
+    {"name": "Mercury Energy Usage Card", "filename": "energy-usage-card.js", "version": INTEGRATION_VERSION},
+    {"name": "Mercury Energy Weekly Summary Card", "filename": "energy-weekly-summary-card.js", "version": INTEGRATION_VERSION},
+    {"name": "Mercury Energy Monthly Summary Card", "filename": "energy-monthly-summary-card.js", "version": INTEGRATION_VERSION},
+]
+```
+
+**ALLOWED_JS_FILES_WHITELIST:**
+```python
+# SOURCE: custom_components/mercury_co_nz/__init__.py:23-29
+# COPY THIS PATTERN — add the new filename:
+ALLOWED_JS_FILES = frozenset({
+    "core.js",
+    "styles.js",
+    "energy-usage-card.js",
+    "energy-weekly-summary-card.js",
+    "energy-monthly-summary-card.js",
+})
+```
+
+**LITELEMENT_CARD_HEADER (top of every card file):**
+```javascript
+// SOURCE: custom_components/mercury_co_nz/energy-usage-card.js:1-7
+// COPY THIS EXACTLY:
+import { LitElement, html, css } from 'https://unpkg.com/lit@3.1.0/index.js?module';
+import { mercuryChartStyles, mercuryColors } from './styles.js';
+import { mercuryLitCore } from './core.js';
+
+class MercuryEnergyUsageCard extends LitElement {
+```
+
+**LITELEMENT_CARD_INIT (mixin composition):**
+```javascript
+// SOURCE: custom_components/mercury_co_nz/energy-usage-card.js:32-50
+// COPY THIS PATTERN — adapted for gas:
+constructor() {
+  super();
+  this.config = {};
+  this._currentPage = 0;
+  this._selectedDate = null;
+  this.itemsPerPage = 6;            // visible bar count per "page"
+  Object.assign(this, mercuryLitCore);
+  this.initializeBase();
+  this.CHART_COLORS = { ...this.CHART_COLORS, ...mercuryColors };
+}
+```
+
+**STATIC_PROPERTIES:**
+```javascript
+// SOURCE: custom_components/mercury_co_nz/energy-monthly-summary-card.js:26-30
+// COPY THIS PATTERN:
+static properties = {
+  hass: { type: Object },
+  config: { type: Object },
+  _entity: { type: Object, state: true }
+};
+```
+
+**CHART_DATASET_PER_BAR_COLOR (the new bit — Chart.js supports color-arrays):**
+```javascript
+// PATTERN (NEW — derived from Chart.js v4 docs and the existing single-color pattern):
+// SOURCE FOR REFERENCE: custom_components/mercury_co_nz/energy-usage-card.js:363-384
+// (the existing monthly bar chart uses single-color backgroundColor; we extend to array)
+
+const barColors = paddedPageData.map(item =>
+  item.consumption === 0 || item.date == null
+    ? this.CHART_COLORS.PRIMARY_YELLOW          // unused/empty pad bars (will be hidden by zero height anyway)
+    : item.is_estimated
+      ? this.CHART_COLORS.SECONDARY_GRAY        // '#727272' — estimated read
+      : this.CHART_COLORS.PRIMARY_YELLOW        // 'rgb(255, 240, 0)' — actual read
+);
+
+return [{
+  label: 'Gas Usage (kWh)',
+  data: usageData,
+  backgroundColor: barColors,                   // ARRAY — one per bar
+  borderColor: barColors,
+  borderWidth: 2,
+  borderRadius: { topLeft: 3, topRight: 3, bottomLeft: 0, bottomRight: 0 },
+  barPercentage: 0.9,
+  type: 'bar',
+  yAxisID: 'y',
+  order: 1
+}];
+```
+
+**NAVIGATION_HANDLER (monthly logic, copy verbatim):**
+```javascript
+// SOURCE: custom_components/mercury_co_nz/energy-usage-card.js:967-1008
+// (copy the monthly branch — drop the daily/hourly branches in the new card)
+_handleNavigation(direction) {
+  // ... reads entity.attributes.gas_monthly_usage_history (was: monthly_usage_history)
+  // ... pages by this._currentPage * this.itemsPerPage
+  // ... no period switcher to coordinate (gas only has monthly)
+}
+```
+
+**LEGEND_CIRCLE_CSS (existing — adapt to two circles):**
+```css
+/* SOURCE: custom_components/mercury_co_nz/styles.js:514-516 */
+/* PATTERN — yellow circle exists; ADD a gray-circle modifier for the legend */
+.legend-circle {
+  background-color: rgb(255, 240, 0); /* PRIMARY_YELLOW — actual */
+}
+.legend-circle.estimated {
+  background-color: #727272;          /* SECONDARY_GRAY — estimated */
+}
+```
+
+**FRONTEND_URL_PATTERN:**
+```python
+# SOURCE: custom_components/mercury_co_nz/__init__.py:32-58
+# Static-served via /api/mercury_co_nz/<filename>; new file slots in transparently.
+class MercuryStaticView(HomeAssistantView):
+    url = f"{URL_BASE}/{{filename:.+}}"   # URL_BASE = "/api/mercury_co_nz"
+    requires_auth = False
+```
+
+**CONSOLE_BANNER (every card file ends with this):**
+```javascript
+// SOURCE: custom_components/mercury_co_nz/energy-monthly-summary-card.js:223-227
+// COPY THIS PATTERN:
+console.info(
+  '%c MERCURY-GAS-MONTHLY-SUMMARY-CARD %c v1.0.0 ',
+  'color: orange; font-weight: bold; background: black',
+  'color: white; font-weight: bold; background: dimgray'
+);
+```
+
+---
+
+## Files to Change
+
+| File                                                                | Action | Justification                                                                          |
+| ------------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------- |
+| `custom_components/mercury_co_nz/const.py`                          | UPDATE | Add `gas_monthly_usage` to `SENSOR_TYPES`; add new card to `JSMODULES`                |
+| `custom_components/mercury_co_nz/sensor.py`                         | UPDATE | Add `gas_monthly_usage` to `CHART_DATA_SENSORS`; populate `gas_monthly_usage_history` attribute on it |
+| `custom_components/mercury_co_nz/__init__.py`                       | UPDATE | Add `gas-monthly-summary-card.js` to `ALLOWED_JS_FILES`                                |
+| `custom_components/mercury_co_nz/gas-monthly-summary-card.js`       | CREATE | The new LitElement card (~600 LOC adapted from `energy-usage-card.js` monthly mode)    |
+| `custom_components/mercury_co_nz/styles.js`                         | UPDATE | Add `.legend-circle.estimated { background-color: #727272 }` modifier                   |
+| `custom_components/mercury_co_nz/manifest.json`                     | UPDATE | Bump version `1.5.2` → `1.6.0` (new minor — adds a feature)                            |
+| `custom_components/mercury_co_nz/tests/test_attributes.py`          | UPDATE | Add a unit test asserting the new `gas_monthly_usage` sensor exposes `gas_monthly_usage_history` |
+
+---
+
+## NOT Building (Scope Limits)
+
+Explicit exclusions to prevent scope creep:
+
+- **Multi-ICP gas support on this card.** Main has single-gas-ICP only (per `mercury_api.get_gas_usage_data` which `break`s after the first gas service). Multi-ICP gas is on the `fix/multi-icp-v200-phases-2-5` branch — this plan ships on `main` and the v2.0.0 branch will get the card via cherry-pick + per-ICP entity multiplication separately.
+- **Daily/hourly tabs.** Mercury's gas API only returns monthly data (confirmed by maintainer testing — see `mercury_api.py:980-984`). No period switcher — the card is monthly-only.
+- **Cost projection / progress-bar features.** Those belong on a separate `gas-monthly-summary-card` companion if requested later. This plan is the bar-chart-with-nav card only.
+- **A new electricity-vs-gas combined card.** Out of scope — keeping gas as a separate card matches the existing pattern.
+- **Sensor-attribute size truncation for gas history.** Gas has ~10 entries × ~200 bytes ≈ 2KB — well under the 14KB HA recorder limit. No `[-CHART_ATTRIBUTE_DAILY_DAYS:]` truncation needed.
+- **Backwards-compat for pymercury <1.1.3.** Manifest already pins `>=1.1.3` — `consumption_periods` is the primary path; the local `_collapse_gas_pairs` fallback in `mercury_api.py:1041` handles 1.1.2 defensively but `is_estimated` may be missing on those entries. Acceptable degradation: gray-vs-yellow falls back to all-yellow when `is_estimated` is undefined.
+- **Tests for the JS card itself.** No frontend test infrastructure exists in this repo (verified — zero JS tests). The Python-side test at Task 7 covers the data plumbing.
+
+---
+
+## Step-by-Step Tasks
+
+Execute in order. Each task is atomic and independently verifiable.
+
+### Task 1: UPDATE `custom_components/mercury_co_nz/const.py` — add gas chart sensor type
+
+- **ACTION**: ADD a new entry to `SENSOR_TYPES` and append a new module to `JSMODULES`
+- **IMPLEMENT**:
+  ```python
+  # In SENSOR_TYPES (after "bill_gas_amount" or at end of bill section):
+  "gas_monthly_usage": {
+      "name": "Gas Monthly Usage",
+      "unit": "kWh",
+      "icon": "mdi:fire",
+      "device_class": "energy",
+      "state_class": "total_increasing",
+  },
+  ```
+  ```python
+  # In JSMODULES, append after the existing entries:
+  {"name": "Mercury Gas Monthly Summary Card", "filename": "gas-monthly-summary-card.js", "version": INTEGRATION_VERSION},
+  ```
+- **MIRROR**: `const.py:160-166` (`bill_electricity_amount` shape) and `const.py:18-22` (existing `JSMODULES` entries)
+- **GOTCHA**: Use `state_class: "total_increasing"` to match how electricity's chart sensor is registered. The unit "kWh" matches the gas billing surface (Mercury bills gas in kWh, not m³). `device_class: "energy"` makes the sensor available to the HA Energy Dashboard's gas section if the user wants to wire it up.
+- **VALIDATE**: `.venv/bin/python -c "from custom_components.mercury_co_nz import const; assert 'gas_monthly_usage' in const.SENSOR_TYPES; assert any(m['filename'] == 'gas-monthly-summary-card.js' for m in const.JSMODULES); print('OK')"`
+
+### Task 2: UPDATE `custom_components/mercury_co_nz/sensor.py` — wire up chart attributes
+
+- **ACTION**: Add `gas_monthly_usage` to `CHART_DATA_SENSORS` AND add a gas branch in `extra_state_attributes` that copies `gas_monthly_usage_history` from `coordinator.data` onto the sensor
+- **IMPLEMENT**:
+  ```python
+  # sensor.py:255-259 — extend the whitelist
+  CHART_DATA_SENSORS = [
+      "energy_usage",
+      "total_usage",
+      "current_bill",
+      "gas_monthly_usage",   # NEW — gas chart sensor
+  ]
+  ```
+  ```python
+  # sensor.py — inside the existing `if self._sensor_type in CHART_DATA_SENSORS:` block,
+  # AFTER the existing electricity monthly_usage_history block at line 321,
+  # add a gas-specific block guarded on the sensor type:
+  if self._sensor_type == "gas_monthly_usage":
+      gas_history = self.coordinator.data.get("gas_monthly_usage_history") or []
+      attributes["gas_monthly_usage_history"] = gas_history
+      attributes["gas_monthly_data_points"] = len(gas_history)
+      attributes["gas_monthly_total_usage"] = self.coordinator.data.get("gas_monthly_usage") or 0
+      attributes["gas_monthly_total_cost"] = self.coordinator.data.get("gas_monthly_cost") or 0
+  ```
+- **MIRROR**: The exact electricity pattern at `sensor.py:317-321`. The gas-specific guard prevents leaking gas attributes onto electricity sensors (which would bloat their already-tight 14KB attribute budget — Issue #4 territory).
+- **GOTCHA**: Don't add the gas attributes to the OUTER (non-CHART) attribute block at `sensor.py:325-340` — that block runs for every sensor and would balloon attribute size on `bill_*` sensors that don't need chart data.
+- **VALIDATE**: `.venv/bin/python -m pytest custom_components/mercury_co_nz/tests/test_attributes.py -v --no-cov`
+
+### Task 3: UPDATE `custom_components/mercury_co_nz/__init__.py` — whitelist the new file
+
+- **ACTION**: Add `"gas-monthly-summary-card.js"` to the `ALLOWED_JS_FILES` frozenset
+- **IMPLEMENT**:
+  ```python
+  # __init__.py:23-29 — extend the frozenset
+  ALLOWED_JS_FILES = frozenset({
+      "core.js",
+      "styles.js",
+      "energy-usage-card.js",
+      "energy-weekly-summary-card.js",
+      "energy-monthly-summary-card.js",
+      "gas-monthly-summary-card.js",   # NEW
+  })
+  ```
+- **MIRROR**: `__init__.py:23-29`
+- **GOTCHA**: The `MercuryStaticView` returns 404 for any filename NOT in this set. Forgetting this entry produces a confusing "card not found" failure with no Python-side error.
+- **VALIDATE**: `.venv/bin/python -c "from custom_components.mercury_co_nz import ALLOWED_JS_FILES; assert 'gas-monthly-summary-card.js' in ALLOWED_JS_FILES; print('OK')"`
+
+### Task 4: CREATE `custom_components/mercury_co_nz/gas-monthly-summary-card.js`
+
+- **ACTION**: CREATE the new LitElement card file by adapting the monthly-mode of `energy-usage-card.js`
+- **IMPLEMENT**: The card is a stripped-down clone of `energy-usage-card.js` with these specific differences:
+  1. **Header / class name / customElement registration:**
+     ```javascript
+     import { LitElement, html, css } from 'https://unpkg.com/lit@3.1.0/index.js?module';
+     import { mercuryChartStyles, mercuryColors } from './styles.js';
+     import { mercuryLitCore } from './core.js';
+
+     class MercuryGasMonthlySummaryCard extends LitElement {
+       static styles = mercuryChartStyles;
+       static properties = {
+         hass: { type: Object },
+         config: { type: Object },
+         _entity: { type: Object, state: true }
+       };
+       // ... constructor with mercuryLitCore mixin (mirror energy-usage-card.js:32-50) ...
+     }
+
+     if (!customElements.get('mercury-gas-monthly-summary-card')) {
+       customElements.define('mercury-gas-monthly-summary-card', MercuryGasMonthlySummaryCard);
+     }
+
+     window.customCards = window.customCards || [];
+     window.customCards.push({
+       type: 'mercury-gas-monthly-summary-card',
+       name: 'Mercury Gas Monthly Summary Card',
+       description: 'Monthly gas consumption bar chart for Mercury Energy NZ',
+       preview: false,
+       documentationURL: 'https://github.com/bkintanar/this-repo'
+     });
+     ```
+  2. **No period switcher.** Hard-code `_currentPeriod = 'monthly'`. Drop the `_renderPeriodTabs()` call.
+  3. **Data source attribute change:** every reference to `entity.attributes.monthly_usage_history` in `energy-usage-card.js` becomes `entity.attributes.gas_monthly_usage_history` in this card. Apply globally — there are ~5 such references (lines 425, 968, 1118, 1163, 1180 in the original).
+  4. **Per-bar coloring (the key new logic):**
+     ```javascript
+     // In _getDatasetsForPeriod() — use a color array instead of a single string:
+     const barColors = paddedPageData.map(item =>
+       item.is_estimated === true
+         ? this.CHART_COLORS.SECONDARY_GRAY     // '#727272'
+         : this.CHART_COLORS.PRIMARY_YELLOW     // 'rgb(255, 240, 0)'
+     );
+
+     return [{
+       label: 'Gas Usage (kWh)',
+       data: usageData,
+       backgroundColor: barColors,
+       borderColor: barColors,
+       borderWidth: 2,
+       borderRadius: { topLeft: 3, topRight: 3, bottomLeft: 0, bottomRight: 0 },
+       barPercentage: 0.9,
+       type: 'bar',
+       yAxisID: 'y',
+       order: 1
+     }];
+     ```
+  5. **Legend (two entries instead of one):**
+     ```javascript
+     _renderChartLegend() {
+       return html`
+         <div class="chart-legend">
+           <div class="legend-item">
+             <span class="legend-circle"></span>
+             <span class="legend-label">Actual</span>
+           </div>
+           <div class="legend-item">
+             <span class="legend-circle estimated"></span>
+             <span class="legend-label">Estimated</span>
+           </div>
+         </div>
+       `;
+     }
+     ```
+  6. **Tooltip / info-box label:** "Your gas usage for this billing period" (instead of electricity wording).
+  7. **No temperature dataset.** The electricity card has a temperature line overlay (`_getDatasetsForPeriod` second dataset). Drop it for gas — gas data has no temperature axis.
+  8. **Console banner at end of file:**
+     ```javascript
+     console.info(
+       '%c MERCURY-GAS-MONTHLY-SUMMARY-CARD %c v1.0.0 ',
+       'color: orange; font-weight: bold; background: black',
+       'color: white; font-weight: bold; background: dimgray'
+     );
+     ```
+- **MIRROR**: `custom_components/mercury_co_nz/energy-usage-card.js` lines 1-7 (header), 32-50 (constructor), 363-384 (monthly dataset config), 425-430 (data source read), 561-585 (label/padding), 967-1008 (navigation), 1117-1124 (nav-disabled bounds), 1161-1197 (nav description), 1274-1286 (info box), 1312-1339 (nav render), 1342-1367 (legend)
+- **GOTCHA 1**: Chart.js dataset config requires `backgroundColor` to be EITHER a single string OR an array of strings with `data.length` matching exactly. If the array length and data length disagree, Chart.js silently falls back to its default palette. Always derive `barColors` from `paddedPageData` (post-padding) so the array is the same length as the data array.
+- **GOTCHA 2**: `entry.is_estimated` may be `undefined` if pymercury 1.1.2 was somehow installed (despite the `>=1.1.3` pin) and the local `_collapse_gas_pairs` fallback fed entries without that key. Use `item.is_estimated === true` (strict comparison) so undefined falls into the actual/yellow path — visible degradation rather than hidden bug.
+- **GOTCHA 3**: When the user clicks a bar, the info panel should also show the read type. Add a small "(estimated)" annotation:
+  ```javascript
+  ${this._selectedDate.is_estimated ? html`<span class="estimate-tag">(estimated)</span>` : ''}
+  ```
+- **VALIDATE**:
+  - File loads without JS error: `node -e "require('fs').readFileSync('custom_components/mercury_co_nz/gas-monthly-summary-card.js', 'utf8')"` (sanity read)
+  - File served by static view: after restart, browser fetch of `http://homeassistant.local:8123/api/mercury_co_nz/gas-monthly-summary-card.js` returns 200 with the JS body
+  - Lovelace UI shows "Mercury Gas Monthly Summary Card" in the card-picker
+
+### Task 5: UPDATE `custom_components/mercury_co_nz/styles.js` — add the gray-circle modifier
+
+- **ACTION**: Add a `.legend-circle.estimated` rule after the existing `.legend-circle` definition
+- **IMPLEMENT**:
+  ```css
+  /* In styles.js around line 514-516, ADD: */
+  .legend-circle.estimated {
+    background-color: #727272;  /* SECONDARY_GRAY */
+  }
+  ```
+- **MIRROR**: `styles.js:514-516` (the existing `.legend-circle` rule sits inside `chartLegendStyles` exported as part of `mercuryChartStyles`)
+- **GOTCHA**: `styles.js` is a JS file using `css` template literals from `lit`. Add the rule inside the same `css\`...\`` block where `.legend-circle` already lives, not as a standalone export.
+- **VALIDATE**: visual check after browser reload — the second legend item ("Estimated") shows a gray circle.
+
+### Task 6: UPDATE `custom_components/mercury_co_nz/manifest.json` — version bump
+
+- **ACTION**: Bump version `1.5.2` → `1.6.0` (minor — new feature)
+- **IMPLEMENT**:
+  ```json
+  "version": "1.6.0"
+  ```
+- **MIRROR**: Existing `manifest.json` shape (line 13)
+- **GOTCHA**: HACS surfaces the update prompt only when this version increments. The `JSMODULES` entries also use `INTEGRATION_VERSION` (= manifest version) as a query string — bumping invalidates the browser cache for ALL cards in this integration, which is desired here so users get the new card without manual hard-refresh.
+- **VALIDATE**: `python3 -c "import json; m=json.load(open('custom_components/mercury_co_nz/manifest.json')); assert m['version']=='1.6.0'; print('OK')"`
+
+### Task 7: UPDATE `custom_components/mercury_co_nz/tests/test_attributes.py` — assert the new attribute path
+
+- **ACTION**: Add a test that constructs a `MercurySensor` with type `"gas_monthly_usage"`, populates `coordinator.data["gas_monthly_usage_history"]` with a sample list, and asserts `extra_state_attributes` includes the chart-ready key
+- **IMPLEMENT**:
+  ```python
+  # Append to test_attributes.py:
+
+  def test_gas_monthly_usage_sensor_exposes_chart_history(coordinator_with_data):
+      """gas_monthly_usage sensor must expose gas_monthly_usage_history as an
+      extra_state_attribute so the gas-monthly-summary-card.js can read it via
+      hass.states[entity_id].attributes.gas_monthly_usage_history.
+      """
+      sample_history = [
+          {"date": "2026-02-26", "consumption": 397.0, "cost": 139.20,
+           "invoice_from": "2026-01-31", "invoice_to": "2026-02-26",
+           "is_estimated": True, "read_type": "estimate", "free_power": False},
+          {"date": "2026-03-27", "consumption": 460.0, "cost": 156.28,
+           "invoice_from": "2026-02-27", "invoice_to": "2026-03-27",
+           "is_estimated": False, "read_type": "actual", "free_power": False},
+      ]
+      coordinator_with_data.data["gas_monthly_usage_history"] = sample_history
+      coordinator_with_data.data["gas_monthly_usage"] = 4842.0
+      coordinator_with_data.data["gas_monthly_cost"] = 1499.42
+
+      from custom_components.mercury_co_nz.sensor import MercurySensor
+      sensor = MercurySensor(
+          coordinator_with_data, "gas_monthly_usage", "Mercury NZ", "user@example.com"
+      )
+
+      attrs = sensor.extra_state_attributes
+      assert attrs["gas_monthly_usage_history"] == sample_history
+      assert attrs["gas_monthly_data_points"] == 2
+      assert attrs["gas_monthly_total_usage"] == 4842.0
+      assert attrs["gas_monthly_total_cost"] == 1499.42
+      # Critical for the card's per-bar coloring:
+      assert attrs["gas_monthly_usage_history"][0]["is_estimated"] is True
+      assert attrs["gas_monthly_usage_history"][1]["is_estimated"] is False
+
+
+  def test_electricity_sensors_do_NOT_get_gas_attributes(coordinator_with_data):
+      """Issue #4 guard: gas attributes must not bleed onto electricity chart
+      sensors — they're already at attribute-size limit."""
+      coordinator_with_data.data["gas_monthly_usage_history"] = [{"date": "2026-03-27"}]
+
+      from custom_components.mercury_co_nz.sensor import MercurySensor
+      sensor = MercurySensor(
+          coordinator_with_data, "energy_usage", "Mercury NZ", "user@example.com"
+      )
+
+      attrs = sensor.extra_state_attributes
+      assert "gas_monthly_usage_history" not in attrs
+  ```
+- **MIRROR**: existing `test_attributes.py` test patterns and fixtures
+- **GOTCHA**: If a `coordinator_with_data` fixture doesn't exist, mirror the construction style from `tests/test_gas_pipeline.py:33-44` (`MagicMock`-based hass + a coordinator stub).
+- **VALIDATE**: `.venv/bin/python -m pytest custom_components/mercury_co_nz/tests/test_attributes.py -v --no-cov`
+
+---
+
+## Testing Strategy
+
+### Unit Tests to Write
+
+| Test File                                                   | Test Cases                                                                                        | Validates                                          |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `custom_components/mercury_co_nz/tests/test_attributes.py` | `test_gas_monthly_usage_sensor_exposes_chart_history`, `test_electricity_sensors_do_NOT_get_gas_attributes` | Sensor attribute population + Issue #4 isolation |
+
+### Edge Cases Checklist
+
+- [ ] Empty `gas_monthly_usage_history` (no gas data ever fetched) → card renders empty/loading state, no JS error
+- [ ] `gas_monthly_usage_history` with all `is_estimated: true` entries → chart shows all gray bars; legend still shows both entries
+- [ ] `gas_monthly_usage_history` with all `is_estimated: false` → all yellow; matches existing electricity look
+- [ ] `is_estimated` undefined on entries (pymercury 1.1.2 fallback) → defaults to yellow (actual)
+- [ ] Single billing period (1 entry) → bar renders, prev arrow disabled, next arrow disabled
+- [ ] Exactly `itemsPerPage` (6) entries → renders one full page, both arrows disabled
+- [ ] More than `itemsPerPage` entries (typical: 10) → first page shows 6 most recent; prev arrow enabled
+- [ ] User clicks empty-pad bar (zero consumption) → info panel handles gracefully (mirror existing card's behavior)
+- [ ] Theme switch (light ↔ dark) mid-session → bar colors stay correct (yellow + gray are theme-independent)
+
+---
+
+## Validation Commands
+
+### Level 1: STATIC_ANALYSIS
+
+```bash
+.venv/bin/python -c "
+import ast
+for p in [
+    'custom_components/mercury_co_nz/sensor.py',
+    'custom_components/mercury_co_nz/const.py',
+    'custom_components/mercury_co_nz/__init__.py',
+]:
+    ast.parse(open(p).read())
+    print(f'OK {p}')
+"
+node --check custom_components/mercury_co_nz/gas-monthly-summary-card.js && echo "JS OK"
+```
+
+**EXPECT**: Exit 0, all files report OK.
+
+### Level 2: UNIT_TESTS
+
+```bash
+.venv/bin/python -m pytest custom_components/mercury_co_nz/tests/ --no-cov -q
+```
+
+**EXPECT**: All previously-passing tests still pass (103 on main pre-change), plus 2 new tests added in Task 7. Total ≥ 105/105 passing.
+
+### Level 3: FULL_SUITE
+
+```bash
+.venv/bin/python -m pytest custom_components/mercury_co_nz/tests/ --no-cov -q && \
+python3 -c "import json; m=json.load(open('custom_components/mercury_co_nz/manifest.json')); print('manifest version:', m['version'])"
+```
+
+**EXPECT**: tests pass, manifest reads `1.6.0`.
+
+### Level 4: DATABASE_VALIDATION
+
+Not applicable — no schema changes (HA recorder schema is owned by HA core).
+
+### Level 5: BROWSER_VALIDATION (manual on a test HA instance)
+
+After deploying and restarting HA fully:
+
+- [ ] `sensor.mercury_nz_gas_monthly_usage` appears in **Developer Tools → States**
+- [ ] Its state shows the gas total kWh and `unit_of_measurement: kWh`
+- [ ] Its `attributes.gas_monthly_usage_history` is a list of ~10 dicts each containing `is_estimated` (true/false), `consumption`, `cost`, `invoice_from`, `invoice_to`
+- [ ] Lovelace card-picker (Settings → Dashboards → Edit → Add Card → Custom) shows "Mercury Gas Monthly Summary Card"
+- [ ] After adding the card with `entity: sensor.mercury_nz_gas_monthly_usage`:
+  - [ ] Bars render
+  - [ ] Months with `is_estimated: true` appear gray
+  - [ ] Months with `is_estimated: false` appear yellow
+  - [ ] Prev/next arrows page correctly
+  - [ ] Clicking a bar shows the period's invoice range, $cost, kWh
+  - [ ] Legend shows both "Actual" (yellow circle) and "Estimated" (gray circle)
+  - [ ] HACS shows v1.6.0 update prompt for any user upgrading from v1.5.2
+- [ ] Browser DevTools → Network: card JS file fetched as `200` from `/api/mercury_co_nz/gas-monthly-summary-card.js?v=1.6.0`
+
+### Level 6: MANUAL_VALIDATION
+
+1. Restart HA fully (not just reload integration — HACS-installed JS modules need full restart).
+2. Verify the new sensor entity appears in Developer Tools → States.
+3. Edit a Lovelace dashboard, add the new card, point it at `sensor.mercury_nz_gas_monthly_usage`.
+4. Compare visual output against the existing electricity card's monthly mode — same look and feel, plus the gray-bar variation.
+5. Cross-check a known estimated month against your actual Mercury bill to confirm the gray bar marks an estimate.
+
+---
+
+## Acceptance Criteria
+
+- [ ] New `sensor.mercury_nz_gas_monthly_usage` entity appears in HA after restart
+- [ ] Entity exposes `gas_monthly_usage_history` (list of ~10 dicts, each including `is_estimated` bool)
+- [ ] New `mercury-gas-monthly-summary-card` registered as a custom card; appears in Lovelace's card-picker
+- [ ] Card renders a bar chart with one bar per billing period
+- [ ] Yellow bars for actual reads (`is_estimated: false`); gray bars for estimates (`is_estimated: true`)
+- [ ] Prev/next month nav works (mirroring electricity card behavior)
+- [ ] Clicking a bar shows that period's invoice range, cost, kWh, and an "(estimated)" tag if applicable
+- [ ] Legend shows both "Actual" and "Estimated" with the right circle colors
+- [ ] No regressions in existing 103 Python tests
+- [ ] Existing electricity sensors do NOT have gas attributes added (Issue #4 size-budget guard preserved)
+- [ ] HACS shows `v1.6.0` upgrade prompt to existing v1.5.2 users
+
+---
+
+## Completion Checklist
+
+- [ ] Task 1: const.py updated (SENSOR_TYPES + JSMODULES)
+- [ ] Task 2: sensor.py updated (CHART_DATA_SENSORS + gas attribute block)
+- [ ] Task 3: __init__.py updated (ALLOWED_JS_FILES)
+- [ ] Task 4: gas-monthly-summary-card.js created
+- [ ] Task 5: styles.js updated (.legend-circle.estimated)
+- [ ] Task 6: manifest.json bumped to 1.6.0
+- [ ] Task 7: test_attributes.py extended with 2 new tests
+- [ ] Level 1 static analysis passes
+- [ ] Level 2 unit tests pass (≥105/105)
+- [ ] Level 3 full suite + manifest check passes
+- [ ] Level 5 browser validation completed on a test HA instance
+- [ ] All acceptance criteria met
+
+---
+
+## Risks and Mitigations
+
+| Risk                                                                                     | Likelihood | Impact | Mitigation                                                                                                                                                                                                  |
+| ---------------------------------------------------------------------------------------- | ---------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `is_estimated` missing from entries because pymercury <1.1.3 is somehow installed        | LOW        | LOW    | Strict comparison `item.is_estimated === true` falls into yellow/actual path on undefined — visible degradation (everything yellow), not silent error. Manifest pin `>=1.1.3` enforced by HA pip resolution. |
+| Chart.js per-bar `backgroundColor` array silently falls back to default if length mismatch | MEDIUM     | LOW    | Always derive `barColors` from the post-padding `paddedPageData`. Explicit unit test in card's render path comparing array lengths. Console-warn if mismatch detected (defensive guard).                    |
+| Adding `gas_monthly_usage` to `CHART_DATA_SENSORS` accidentally also gives it electricity history attributes | LOW | MED | The gas-attribute block is specifically guarded `if self._sensor_type == "gas_monthly_usage":`. The electricity blocks are also implicit-typed (they read `daily_usage_history` keys that don't exist for gas data). Test 7 (`test_electricity_sensors_do_NOT_get_gas_attributes`) is the load-bearing assertion. |
+| Sensor attribute size grows past 14KB                                                    | LOW        | LOW    | Gas has ~10 entries × ~250 bytes ≈ 2.5KB. Order of magnitude under the limit. No truncation needed. Test on real production data once deployed.                                                            |
+| HACS-installed users don't see the new card without HA restart                           | MEDIUM     | LOW    | Document in README; mirror the v1.5.2 PR's migration note ("Settings → System → Restart Home Assistant"). Version bump to 1.6.0 invalidates browser cache via the `?v=1.6.0` query param on JS resource URL. |
+| User has gas service but `gas_monthly_usage_history` is empty (Mercury returned no data) | MEDIUM     | LOW    | Card renders the existing loading-state path. Same UX as electricity card pre-data. No new error path needed.                                                                                              |
+| New sensor accidentally breaks the v2.0.0 multi-ICP cherry-pick                          | MEDIUM     | MED    | The v2.0.0 branch has its own gas data path (per-ICP keys). Cherry-picking this card's commit will conflict on `sensor.py` and `mercury_api.py`. Resolution: re-implement the gas-history attribute population per-ICP on v2.0.0; the card itself (JS file) cherry-picks cleanly. Document in PR description.    |
+
+---
+
+## Notes
+
+**Why a separate card (not a tab on the existing electricity card?):**
+
+The electricity card has its monthly mode tightly integrated with hourly/daily — they share period-tab state, navigation history, and a temperature overlay. Folding gas in as a fourth tab would either: (a) require runtime branching on which fuel is currently selected and toggling temperature/coloring conditionally, doubling the card's logic surface; or (b) force a "fuel selector" on top of the period selector, which is a worse UX. A separate card mirrors the existing pattern (`energy-usage-card.js` is one card, `energy-weekly-summary-card.js` is another, `energy-monthly-summary-card.js` is a third) and keeps gas's monthly-only nature explicit in the card's name and shape.
+
+**Why `device_class: "energy"` on the gas sensor:**
+
+Even though Mercury bills gas in kWh equivalent, classifying as `energy` makes the new sensor compatible with HA's Energy Dashboard "Gas" section if the user wants to wire it up directly (vs. the existing statistics-importer-driven path). Consistent with electricity's chart sensor classification.
+
+**Why no daily/hourly tabs on the gas card:**
+
+Mercury's gas API returns empty `usage` arrays for `interval='daily'` and `'hourly'` requests on every account we've tested (documented in `mercury_api.py:980-984`). No reason to build UI for data Mercury doesn't expose.
+
+**Color contrast accessibility:**
+
+Yellow `rgb(255, 240, 0)` on the chart's dark background and gray `#727272` are visually distinguishable for the typical viewer. For colorblind users (deuteranopia, protanopia), brightness contrast (yellow is brighter than gray) supplements the hue distinction. Not a perfect accessibility solution; a future enhancement could add a hatch/pattern on estimated bars (Chart.js supports `pattern` plugin).
+
+**v2.0.0 multi-ICP roadmap:**
+
+This plan ships on `main` as v1.6.0. When the v2.0.0 branch (`fix/multi-icp-v200-phases-2-5`) is ready to merge, the card needs to be made multi-ICP-aware: the per-ICP attribute keys (`icp_<token>_gas_monthly_usage_history`) map to per-ICP sensor entities, and the user adds one card per gas ICP pointing at the right entity. The card JS itself doesn't need to change — only the Python side gets the per-ICP entity multiplication that v2.0.0 already implements for electricity.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ name: Monthly Summary
 
 ![Energy Monthly Summary](assets/monthly-summary.png)
 
+### Gas Monthly Usage (v1.6.0+)
+
+```yaml
+type: custom:mercury-gas-monthly-summary-card
+entity: sensor.mercury_nz_gas_monthly_usage
+name: Gas Monthly Usage
+```
+
+A bar chart of monthly gas consumption with the same prev/next nav as the
+electricity card. **Yellow** bars are actual meter reads; **gray** bars are
+Mercury estimates. Click any bar to see that period's invoice range, cost,
+and kWh. Requires a Mercury account with gas service.
+
 ## ✨ Features
 
 ### 📊 Interactive Chart Card
@@ -98,7 +111,7 @@ If your Mercury account includes gas service (alongside electricity, or gas-only
 
 - **Energy Dashboard → Monthly tab**: gas bars at correct totals per month — matches your Mercury bill. ✅
 - **Energy Dashboard → Daily / Hourly tabs**: a single bar per Mercury invoice period at `invoice_to`. The daily/hourly views still work but show monthly granularity — this is an honest representation of what Mercury actually provides (no synthetic sub-monthly distribution).
-- **Live `sensor.mercury_nz_gas_*` entities**: not provided in v1.4.0 (would require sub-monthly data Mercury doesn't expose).
+- **Live `sensor.mercury_nz_gas_monthly_usage` entity** (v1.6.0+): exposes the per-period gas history (kWh, cost, invoice dates, `is_estimated` tag) as `extra_state_attributes` so the new `mercury-gas-monthly-summary-card` Lovelace card can render a bar chart with month-by-month nav. The entity itself reports the current rolling kWh total. Daily/hourly gas entities are still not available — Mercury simply doesn't expose sub-monthly data.
 
 **Setup:**
 
@@ -298,6 +311,34 @@ The monthly summary card displays:
 - **Days remaining** in the current billing period
 - **Progress bar** showing how much of the billing period has elapsed
 - **Projected bill amount** extracted from Mercury's billing notes
+
+### Gas Monthly Usage Card (v1.6.0+)
+
+```yaml
+type: custom:mercury-gas-monthly-summary-card
+entity: sensor.mercury_nz_gas_monthly_usage
+name: Gas Monthly Usage
+```
+
+#### Gas Card Configuration
+
+| Option            | Type    | Default             | Description                                  |
+| ----------------- | ------- | ------------------- | -------------------------------------------- |
+| `entity`          | string  | **Required**        | Must be `sensor.mercury_nz_gas_monthly_usage` |
+| `name`            | string  | "Gas Monthly Usage" | Card title                                   |
+| `show_navigation` | boolean | `true`              | Show previous/next page arrows               |
+
+The gas card displays:
+
+- **Bar chart** of monthly gas consumption (kWh) — one bar per Mercury invoice period
+- **Per-bar coloring**: yellow `rgb(255, 240, 0)` for actual meter reads, gray `#727272` for Mercury estimates
+- **Page navigation** with prev/next arrows when more than 6 periods of history are available
+- **Click-to-select**: click any bar to see that period's invoice range (e.g. `27 Feb 2026 – 27 Mar 2026`), cost, and kWh — with an `(estimated)` annotation when applicable
+- **Legend** showing both "Actual" and "Estimated" indicators
+
+> **Requirements**: Mercury account with gas service AND `mercury-co-nz-api>=1.1.3` (auto-installed via `manifest.json`). The `is_estimated` flag on each period drives the color choice — comes from pymercury's `consumption_periods` collapse of Mercury's parallel estimate/actual pair structure.
+
+> **Note**: After upgrading to v1.6.0 from an older version, perform a **full Home Assistant restart** (Settings → System → Restart) — not just a config-entry reload — so the new sensor entity and JS card load from disk. HACS-installed Python modules are not hot-swapped on file update.
 
 ## 🛠️ Development
 

--- a/custom_components/mercury_co_nz/__init__.py
+++ b/custom_components/mercury_co_nz/__init__.py
@@ -26,6 +26,7 @@ ALLOWED_JS_FILES = frozenset({
     "energy-usage-card.js",
     "energy-weekly-summary-card.js",
     "energy-monthly-summary-card.js",
+    "gas-monthly-summary-card.js",
 })
 
 

--- a/custom_components/mercury_co_nz/const.py
+++ b/custom_components/mercury_co_nz/const.py
@@ -19,6 +19,7 @@ JSMODULES: Final[list[dict[str, str]]] = [
     {"name": "Mercury Energy Usage Card", "filename": "energy-usage-card.js", "version": INTEGRATION_VERSION},
     {"name": "Mercury Energy Weekly Summary Card", "filename": "energy-weekly-summary-card.js", "version": INTEGRATION_VERSION},
     {"name": "Mercury Energy Monthly Summary Card", "filename": "energy-monthly-summary-card.js", "version": INTEGRATION_VERSION},
+    {"name": "Mercury Gas Monthly Summary Card", "filename": "gas-monthly-summary-card.js", "version": INTEGRATION_VERSION},
 ]
 
 # Configuration keys
@@ -169,6 +170,16 @@ SENSOR_TYPES = {
         "unit": "$",
         "icon": "mdi:fire",
         "device_class": "monetary",
+        "state_class": "total",
+    },
+    "gas_monthly_usage": {
+        "name": "Gas Monthly Usage",
+        "unit": "kWh",
+        "icon": "mdi:fire",
+        "device_class": "energy",
+        # Same windowed-sum reasoning as electricity total_usage — Mercury
+        # reports a rolling year-to-date gas total that can roll forward,
+        # so total_increasing would corrupt long-term-stat accumulators.
         "state_class": "total",
     },
     "bill_broadband_amount": {

--- a/custom_components/mercury_co_nz/gas-monthly-summary-card.js
+++ b/custom_components/mercury_co_nz/gas-monthly-summary-card.js
@@ -1,0 +1,532 @@
+// Mercury Gas Monthly Summary Card for Home Assistant (LitElement)
+// Monthly bar chart with prev/next nav for gas consumption.
+// Bars are colored per-period: yellow for actual reads, gray for estimates.
+// Mirrors the monthly mode of energy-usage-card.js but specialized for gas
+// (no period switcher, no temperature overlay).
+
+import { LitElement, html, css } from 'https://unpkg.com/lit@3.1.0/index.js?module';
+import { mercuryChartStyles, mercuryColors } from './styles.js';
+import { mercuryLitCore } from './core.js';
+
+class MercuryGasMonthlySummaryCard extends LitElement {
+  static styles = [
+    mercuryChartStyles,
+    css`
+      /* Gas card-specific overrides — .legend-circle.estimated lives
+         in chartLegendStyles for cross-card reuse. */
+      .estimate-tag {
+        margin-left: 6px;
+        opacity: 0.75;
+        font-style: italic;
+      }
+    `
+  ];
+
+  static properties = {
+    hass: { type: Object },
+    config: { type: Object },
+    _entity: { type: Object, state: true },
+    _chartLoaded: { type: Boolean, state: true },
+    _chart: { type: Object, state: true },
+    _currentPage: { type: Number, state: true },
+    _selectedDate: { type: Object, state: true }
+  };
+
+  constructor() {
+    super();
+    Object.assign(this, mercuryLitCore);
+    this.initializeBase();
+
+    this._currentPage = 0;
+    this._selectedDate = null;
+    this.itemsPerPage = 6;
+
+    // Initialised here so the Chart.js onClick callback never reads
+    // undefined if a click somehow arrives before the chart is built.
+    this.chartRawData = { usage: [] };
+
+    this.CHART_COLORS = {
+      ...this.CHART_COLORS,
+      ...mercuryColors
+    };
+
+    this._setupVisibilityObserver();
+  }
+
+  setConfig(config) {
+    this.config = this.setConfigBase(config, 'Gas Monthly Usage');
+    this.config = {
+      show_navigation: true,
+      ...this.config
+    };
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.setupLifecycleBase();
+  }
+
+  firstUpdated() {
+    super.firstUpdated();
+    this._hasChartData = this._hasChartData.bind(this);
+    this.handleFirstUpdatedBase();
+  }
+
+  updated(changedProps) {
+    super.updated(changedProps);
+    this.handleUpdatedBase(changedProps);
+
+    if (changedProps.has('hass') && this.hass) {
+      const newEntity = this._getEntity();
+      if (newEntity) {
+        this._entity = newEntity;
+        this._applyThemeAdjustments();
+      }
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.cleanupLifecycleBase();
+  }
+
+  _hasChartData() {
+    const entity = this._getEntity();
+    if (!entity || !entity.attributes) return false;
+    const history = entity.attributes.gas_monthly_usage_history;
+    return Array.isArray(history) && history.length > 0;
+  }
+
+  _getRawData(entity) {
+    return entity.attributes.gas_monthly_usage_history || [];
+  }
+
+  // Sort newest-first for pagination, page slice oldest-first for chart left-to-right.
+  _getPaginatedData(rawData) {
+    if (!rawData.length) return { sortedData: [], pageData: [] };
+
+    const sortedData = [...rawData].sort(
+      (a, b) => new Date(b.invoice_to || b.date) - new Date(a.invoice_to || a.date)
+    );
+
+    let startIndex = this._currentPage * this.itemsPerPage;
+    let endIndex = Math.min(startIndex + this.itemsPerPage, sortedData.length);
+
+    // When the last page has fewer than itemsPerPage entries, slide the
+    // window back so we always show a full page if data permits.
+    const maxPage = Math.ceil(sortedData.length / this.itemsPerPage) - 1;
+    if (this._currentPage === maxPage && sortedData.length >= this.itemsPerPage) {
+      const remainingItems = sortedData.length - startIndex;
+      if (remainingItems < this.itemsPerPage) {
+        endIndex = sortedData.length;
+        startIndex = Math.max(0, endIndex - this.itemsPerPage);
+      }
+    }
+
+    const pageData = sortedData
+      .slice(startIndex, endIndex)
+      .sort((a, b) => new Date(a.invoice_to || a.date) - new Date(b.invoice_to || b.date));
+
+    return { sortedData, pageData };
+  }
+
+  // Pad to itemsPerPage so bar widths stay proportional when fewer than 6 periods exist.
+  _padPageData(pageData) {
+    const padded = [...pageData];
+    while (padded.length < this.itemsPerPage) {
+      padded.push({ date: null, consumption: 0, cost: 0, is_estimated: false });
+    }
+    return padded;
+  }
+
+  _formatChartLabels(paddedData) {
+    return paddedData.map((item) => {
+      const dateStr = item.invoice_to || item.date;
+      if (!dateStr) return '';
+      const date = new Date(dateStr);
+      const day = date.getDate();
+      const month = date.toLocaleDateString('en-NZ', { month: 'short' });
+      return `${day} ${month}`;
+    });
+  }
+
+  _buildBarColors(paddedData) {
+    return paddedData.map((item) =>
+      item.is_estimated === true
+        ? this.CHART_COLORS.SECONDARY_GRAY
+        : this.CHART_COLORS.PRIMARY_YELLOW
+    );
+  }
+
+  _buildDatasets(usageData, barColors) {
+    return [{
+      label: 'Gas Usage (kWh)',
+      data: usageData,
+      backgroundColor: barColors,
+      borderColor: barColors,
+      borderWidth: 2,
+      borderRadius: { topLeft: 3, topRight: 3, bottomLeft: 0, bottomRight: 0 },
+      barPercentage: 0.9,
+      type: 'bar',
+      yAxisID: 'y',
+      order: 1
+    }];
+  }
+
+  // Single source of truth for chart-data derivation. Used by both the
+  // create path (_createOrUpdateChart) and the update path (_updateChartData).
+  _buildChartView(rawData) {
+    const { pageData } = this._getPaginatedData(rawData);
+    const paddedData = this._padPageData(pageData);
+    return {
+      pageData,
+      labels: this._formatChartLabels(paddedData),
+      usageData: paddedData.map((item) => item.consumption || 0),
+      barColors: this._buildBarColors(paddedData)
+    };
+  }
+
+  async _createOrUpdateChart() {
+    if (!this._chartLoaded) {
+      await this._loadChartJS();
+    }
+    await this.updateComplete;
+
+    const entity = this._getEntity();
+    if (!entity || !entity.attributes) return;
+
+    const rawData = this._getRawData(entity);
+    if (!rawData.length) return;
+
+    const canvas = this.shadowRoot.getElementById('gasChart');
+    if (!canvas) {
+      setTimeout(() => {
+        if (this.shadowRoot.getElementById('gasChart')) this._createOrUpdateChart();
+      }, 100);
+      return;
+    }
+
+    if (!this._isCardVisible()) return;
+
+    if (canvas.offsetWidth === 0 || canvas.offsetHeight === 0) {
+      if (this._isCardVisible()) {
+        setTimeout(() => this._createOrUpdateChart(), 100);
+      }
+      return;
+    }
+
+    // If a chart already exists, delegate the data refresh to _updateChartData
+    // so the dataset-update logic lives in one place.
+    if (this._chart && this._chart.data) {
+      this._updateChartData();
+      return;
+    }
+
+    if (this._chart) {
+      this._chart.destroy();
+      this._chart = null;
+    }
+
+    const { pageData, labels, usageData, barColors } = this._buildChartView(rawData);
+    const datasets = this._buildDatasets(usageData, barColors);
+    const ctx = canvas.getContext('2d');
+    this._chart = new Chart(ctx, {
+      type: 'bar',
+      data: { labels, datasets },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        animation: { duration: 1500, easing: 'easeOutCubic' },
+        plugins: {
+          legend: { display: false },
+          tooltip: { enabled: false }
+        },
+        scales: {
+          x: {
+            grid: { display: false },
+            ticks: {
+              color: this._getThemeColor('--secondary-text-color'),
+              font: { size: 12 }
+            }
+          },
+          y: {
+            beginAtZero: true,
+            grid: { color: this._getThemeColor('--divider-color', 0.3) },
+            ticks: {
+              color: this._getThemeColor('--secondary-text-color'),
+              font: { size: 11 }
+            },
+            title: {
+              display: true,
+              text: 'kWh',
+              color: this._getThemeColor('--primary-text-color'),
+              align: 'end',
+              font: { size: 12, weight: 600 }
+            }
+          }
+        },
+        onClick: (event, elements) => {
+          if (elements.length > 0) {
+            const dataIndex = elements[0].index;
+            const selectedItem = this.chartRawData.usage[dataIndex];
+            if (selectedItem) this._updateSelectedInfo(selectedItem);
+          } else if (this.chartRawData.usage.length > 0) {
+            this._updateSelectedInfo(this.chartRawData.usage[this.chartRawData.usage.length - 1]);
+          }
+        },
+        onHover: (event, elements) => {
+          if (event.native && event.native.target) {
+            event.native.target.style.cursor = elements.length > 0 ? 'pointer' : 'default';
+          }
+        }
+      }
+    });
+
+    this.chartRawData = { usage: pageData };
+
+    if (pageData.length > 0 && !this._selectedDate) {
+      this._updateSelectedInfo(pageData[pageData.length - 1]);
+    }
+  }
+
+  _updateChartData() {
+    if (!this._chart) {
+      this._createOrUpdateChart();
+      return;
+    }
+
+    const entity = this._getEntity();
+    if (!entity) return;
+
+    const rawData = this._getRawData(entity);
+    const { pageData, labels, usageData, barColors } = this._buildChartView(rawData);
+
+    this._chart.data.labels = labels;
+    this._chart.data.datasets[0].data = usageData;
+    this._chart.data.datasets[0].backgroundColor = barColors;
+    this._chart.data.datasets[0].borderColor = barColors;
+    this._chart.update('none');
+
+    this.chartRawData = { usage: pageData };
+
+    if (pageData.length > 0 && !this._selectedDate) {
+      this._updateSelectedInfo(pageData[pageData.length - 1]);
+    }
+    this.requestUpdate();
+  }
+
+  _updateSelectedInfo(selectedItem) {
+    if (!selectedItem) return;
+    const dateStr = selectedItem.invoice_to || selectedItem.date;
+    const date = new Date(dateStr);
+    const dateFormatted = this._formatDate(date, { month: 'long', year: 'numeric' });
+
+    this._selectedDate = {
+      date: dateStr,
+      dateFormatted,
+      cost: selectedItem.cost || 0,
+      consumption: selectedItem.consumption || 0,
+      is_estimated: selectedItem.is_estimated === true,
+      rawItem: selectedItem
+    };
+    this.requestUpdate();
+  }
+
+  _handleNavigation(direction) {
+    const entity = this._getEntity();
+    if (!entity) return;
+
+    const rawData = this._getRawData(entity);
+    const maxPage = Math.ceil(rawData.length / this.itemsPerPage) - 1;
+
+    if (direction === 'next' && this._currentPage > 0) {
+      this._currentPage--;
+      this._selectedDate = null;
+      this._updateChartData();
+    } else if (direction === 'prev' && maxPage > 0 && this._currentPage < maxPage) {
+      // maxPage > 0 short-circuits single-page datasets so a programmatic
+      // call (or a click that slipped past the disabled-arrow visibility
+      // guard) cannot push _currentPage off the end into a blank window.
+      this._currentPage++;
+      this._selectedDate = null;
+      this._updateChartData();
+    }
+  }
+
+  _hasPreviousPageData() {
+    const entity = this._getEntity();
+    if (!entity) return false;
+    const rawData = this._getRawData(entity);
+    const nextPageStartIndex = (this._currentPage + 1) * this.itemsPerPage;
+    return rawData.length > nextPageStartIndex;
+  }
+
+  _hasNextPageData() {
+    return this._currentPage > 0;
+  }
+
+  _isNavDisabled(direction) {
+    if (direction === 'prev') return !this._hasPreviousPageData();
+    if (direction === 'next') return !this._hasNextPageData();
+    return false;
+  }
+
+  // Format a billing period as "1 Feb 2026 - 27 Mar 2026\n&nbsp;", or null
+  // when the entry doesn't have both invoice anchors (gas pipeline
+  // guarantees snake_case via pymercury consumption_periods + the local
+  // _collapse_gas_pairs fallback — no camelCase shape exists for gas).
+  _formatInvoiceRange(item) {
+    const from = item.invoice_from;
+    const to = item.invoice_to;
+    if (!from || !to) return null;
+    const opts = { day: 'numeric', month: 'short', year: 'numeric' };
+    const fromStr = new Date(from).toLocaleDateString('en-NZ', opts);
+    const toStr = new Date(to).toLocaleDateString('en-NZ', opts);
+    return `${fromStr} - ${toStr}\n&nbsp;`;
+  }
+
+  _getNavigationDescription() {
+    const entity = this._getEntity();
+    if (!entity) return 'No data available';
+
+    try {
+      if (this._selectedDate && this._selectedDate.rawItem) {
+        const range = this._formatInvoiceRange(this._selectedDate.rawItem);
+        if (range) return range;
+      }
+
+      const rawData = this._getRawData(entity);
+      const { pageData } = this._getPaginatedData(rawData);
+      if (pageData.length === 0) return 'No monthly gas data available';
+
+      const latest = pageData[pageData.length - 1];
+      const range = this._formatInvoiceRange(latest);
+      if (range) return range;
+
+      const dateStr = latest.invoice_to || latest.date;
+      return `${new Date(dateStr).toLocaleDateString('en-NZ', { month: 'short', year: 'numeric' })}\n&nbsp;`;
+    } catch (error) {
+      console.error('Error generating navigation description:', error);
+      return 'Data unavailable';
+    }
+  }
+
+  _shouldShowNavigation(rawData) {
+    return rawData.length > 0;
+  }
+
+  render() {
+    const validationError = this._validateRenderConditions();
+    if (validationError) return validationError;
+
+    const entity = this._getEntity();
+    if (!this._hasChartData()) {
+      return this._renderLoadingState('Loading Gas Monthly Data...', '🔥');
+    }
+    return this._renderGasCard(entity);
+  }
+
+  _renderGasCard(entity) {
+    const rawData = this._getRawData(entity);
+    const showNavigation = this.config.show_navigation && this._shouldShowNavigation(rawData);
+
+    return html`
+      <ha-card class="mercury-chart-card">
+        <div class="card-content">
+          <div class="header">
+            <div class="title-row">
+              <h3>${this.config.name}</h3>
+            </div>
+          </div>
+
+          ${showNavigation ? this._renderNavigation() : ''}
+
+          <div class="chart-container">
+            <canvas id="gasChart" width="400" height="200"></canvas>
+          </div>
+
+          ${this._renderCustomLegend()}
+
+          <div class="chart-info">
+            <div class="data-info">
+              ${this._selectedDate ? html`
+                <div class="usage-details">
+                  <div class="usage-date">
+                    Your gas usage for this billing period
+                    ${this._selectedDate.is_estimated ? html`<span class="estimate-tag">(estimated)</span>` : ''}
+                  </div>
+                  <div class="usage-stats">$${this._selectedDate.cost.toFixed(2)} | ${this._selectedDate.consumption.toFixed(2)} kWh</div>
+                </div>
+              ` : html`Loading...`}
+            </div>
+          </div>
+        </div>
+      </ha-card>
+    `;
+  }
+
+  _renderNavigation() {
+    const description = this._getNavigationDescription();
+    const formattedDescription = description.replace(/\n/g, '<br/>');
+
+    return html`
+      <div class="navigation">
+        <div class="nav-info">
+          <div class="nav-date-container">
+            <div class="nav-column nav-column-left">
+              <span
+                class="nav-arrow ${this._isNavDisabled('prev') ? 'nav-arrow-hidden' : ''}"
+                @click=${() => !this._isNavDisabled('prev') && this._handleNavigation('prev')}
+              >&lt;</span>
+            </div>
+            <div class="nav-column nav-column-center">
+              <span class="nav-date" .innerHTML=${formattedDescription}></span>
+            </div>
+            <div class="nav-column nav-column-right">
+              <span
+                class="nav-arrow ${this._isNavDisabled('next') ? 'nav-arrow-hidden' : ''}"
+                @click=${() => !this._isNavDisabled('next') && this._handleNavigation('next')}
+              >&gt;</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  _renderCustomLegend() {
+    return html`
+      <div class="custom-legend">
+        <div class="legend-item">
+          <div class="legend-circle"></div>
+          <span class="legend-label">Actual</span>
+        </div>
+        <div class="legend-item">
+          <div class="legend-circle estimated"></div>
+          <span class="legend-label">Estimated</span>
+        </div>
+      </div>
+    `;
+  }
+}
+
+if (!customElements.get('mercury-gas-monthly-summary-card')) {
+  customElements.define('mercury-gas-monthly-summary-card', MercuryGasMonthlySummaryCard);
+}
+
+if (window.customCards) {
+  window.customCards = window.customCards || [];
+  window.customCards.push({
+    type: 'mercury-gas-monthly-summary-card',
+    name: 'Mercury Gas Monthly Summary Card',
+    description: 'Monthly gas consumption bar chart for Mercury Energy NZ (estimate vs actual)',
+    preview: false,
+    documentationURL: 'https://github.com/bkintanar/home-assistant-mercury-co-nz'
+  });
+}
+
+console.info(
+  '%c MERCURY-GAS-MONTHLY-SUMMARY-CARD %c v1.6.0 ',
+  'color: orange; font-weight: bold; background: black',
+  'color: white; font-weight: bold; background: dimgray'
+);

--- a/custom_components/mercury_co_nz/manifest.json
+++ b/custom_components/mercury_co_nz/manifest.json
@@ -10,5 +10,5 @@
   "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.3"],
   "frontend": true,
   "min_ha_version": "2025.11.0",
-  "version": "1.5.2"
+  "version": "1.6.0"
 }

--- a/custom_components/mercury_co_nz/sensor.py
+++ b/custom_components/mercury_co_nz/sensor.py
@@ -320,7 +320,23 @@ class MercurySensor(CoordinatorEntity, SensorEntity):
                 attributes["monthly_usage_history"] = monthly_history
                 attributes["monthly_data_points"] = len(monthly_history)
 
-
+        # Gas chart history — sibling to (not inside) the electricity
+        # CHART_DATA_SENSORS block so the gas sensor doesn't inherit
+        # electricity history attributes that would push it toward the 14KB
+        # cap (Issue #4). Each entry in gas_monthly_usage_history carries
+        # `is_estimated`/`read_type` tags from pymercury's consumption_periods
+        # (1.1.3+) which gas-monthly-summary-card.js uses to color bars
+        # (yellow=actual, gray=estimated).
+        if self._sensor_type == "gas_monthly_usage":
+            gas_history = self.coordinator.data.get("gas_monthly_usage_history") or []
+            attributes["gas_monthly_usage_history"] = gas_history
+            attributes["gas_monthly_data_points"] = len(gas_history)
+            attributes["gas_monthly_total_usage"] = (
+                self.coordinator.data.get("gas_monthly_usage") or 0
+            )
+            attributes["gas_monthly_total_cost"] = (
+                self.coordinator.data.get("gas_monthly_cost") or 0
+            )
 
         # Add bill statement details for all sensors (if available)
         if "bill_statement_details" in self.coordinator.data:

--- a/custom_components/mercury_co_nz/styles.js
+++ b/custom_components/mercury_co_nz/styles.js
@@ -512,8 +512,12 @@ export const chartLegendStyles = css`
     width: 12px;
     height: 12px;
     border-radius: 50%;
-    background-color: rgb(255, 240, 0); /* PRIMARY_YELLOW */
+    background-color: rgb(255, 240, 0); /* PRIMARY_YELLOW (actual reads) */
     border: 1px solid rgba(0, 0, 0, 0.1);
+  }
+
+  .legend-circle.estimated {
+    background-color: #727272; /* SECONDARY_GRAY (estimated reads) */
   }
 
   .legend-line {

--- a/custom_components/mercury_co_nz/tests/test_attributes.py
+++ b/custom_components/mercury_co_nz/tests/test_attributes.py
@@ -203,3 +203,125 @@ def test_truncation_keeps_most_recent_entries() -> None:
     assert daily[-1]["date"] == expected_last, (
         f"last kept entry should be {expected_last}, got {daily[-1]['date']}"
     )
+
+
+# ----------------------------------------------------------------------------
+# v1.6.0 — gas chart attribute exposure (gas-monthly-summary-card.js)
+# ----------------------------------------------------------------------------
+
+
+def _coordinator_with_gas_data():
+    """Build a coordinator stub holding only gas-side data, mirroring what
+    coordinator.py:169-176 produces after `gas_` prefixing."""
+    coord = MagicMock()
+    coord.data = {
+        "gas_monthly_usage_history": [
+            {
+                "date": "2026-02-26",
+                "consumption": 397.0,
+                "cost": 139.20,
+                "free_power": False,
+                "invoice_from": "2026-01-31",
+                "invoice_to": "2026-02-26",
+                "is_estimated": True,
+                "read_type": "estimate",
+            },
+            {
+                "date": "2026-03-27",
+                "consumption": 460.0,
+                "cost": 156.28,
+                "free_power": False,
+                "invoice_from": "2026-02-27",
+                "invoice_to": "2026-03-27",
+                "is_estimated": False,
+                "read_type": "actual",
+            },
+        ],
+        "gas_monthly_usage": 4842.0,
+        "gas_monthly_cost": 1499.42,
+        # Electricity data NOT present — the gas card must not depend on it.
+    }
+    coord.last_update_success = True
+    return coord
+
+
+def test_gas_monthly_usage_sensor_exposes_chart_history() -> None:
+    """The gas_monthly_usage sensor must expose gas_monthly_usage_history as
+    an extra_state_attribute so gas-monthly-summary-card.js can read it via
+    hass.states[entity_id].attributes.gas_monthly_usage_history.
+    """
+    coord = _coordinator_with_gas_data()
+    sensor = MercurySensor(coord, "gas_monthly_usage", DEFAULT_NAME, "test@example.com")
+
+    attrs = sensor.extra_state_attributes
+    assert attrs["gas_monthly_usage_history"] == coord.data["gas_monthly_usage_history"]
+    assert attrs["gas_monthly_data_points"] == 2
+    assert attrs["gas_monthly_total_usage"] == 4842.0
+    assert attrs["gas_monthly_total_cost"] == 1499.42
+
+    # LOAD-BEARING for per-bar coloring — the card maps is_estimated → color.
+    assert attrs["gas_monthly_usage_history"][0]["is_estimated"] is True
+    assert attrs["gas_monthly_usage_history"][1]["is_estimated"] is False
+
+
+def test_gas_monthly_usage_native_value_reads_total() -> None:
+    """The sensor's native_value must be the kWh scalar, not the history list."""
+    coord = _coordinator_with_gas_data()
+    sensor = MercurySensor(coord, "gas_monthly_usage", DEFAULT_NAME, "test@example.com")
+    assert sensor.native_value == 4842.0
+
+
+def test_electricity_sensors_do_not_get_gas_attributes() -> None:
+    """Issue #4 isolation: gas attributes must NOT bleed onto electricity
+    chart sensors — they're already near the 14KB attribute-size budget."""
+    coord = _coordinator_with_synthetic_data()
+    coord.data["gas_monthly_usage_history"] = [
+        {
+            "date": "2026-03-27", "consumption": 460.0, "cost": 156.28,
+            "invoice_from": "2026-02-27", "invoice_to": "2026-03-27",
+            "is_estimated": False, "read_type": "actual", "free_power": False,
+        }
+    ]
+    coord.data["gas_monthly_usage"] = 460.0
+    coord.data["gas_monthly_cost"] = 156.28
+
+    sensor = MercurySensor(coord, "energy_usage", DEFAULT_NAME, "test@example.com")
+    attrs = sensor.extra_state_attributes
+
+    assert "gas_monthly_usage_history" not in attrs
+    assert "gas_monthly_data_points" not in attrs
+    assert "gas_monthly_total_usage" not in attrs
+    assert "gas_monthly_total_cost" not in attrs
+
+
+def test_gas_sensor_stays_under_safety_budget() -> None:
+    """Gas history is ~10 entries × ~250 bytes ≈ 2.5KB. Verify the gas chart
+    sensor's attributes are well under the 14KB safety budget even with a
+    full year of data."""
+    base_date = date(2026, 1, 1)
+    coord = MagicMock()
+    coord.data = {
+        "gas_monthly_usage_history": [
+            {
+                "date": (base_date + timedelta(days=30 * i)).isoformat(),
+                "consumption": 400.0 + i * 50,
+                "cost": 130.50 + i * 15,
+                "free_power": False,
+                "invoice_from": (base_date + timedelta(days=30 * i - 28)).isoformat(),
+                "invoice_to": (base_date + timedelta(days=30 * i)).isoformat(),
+                "is_estimated": (i % 2 == 0),
+                "read_type": "estimate" if (i % 2 == 0) else "actual",
+            }
+            for i in range(12)
+        ],
+        "gas_monthly_usage": 5400.0,
+        "gas_monthly_cost": 1700.0,
+    }
+    coord.last_update_success = True
+
+    sensor = MercurySensor(coord, "gas_monthly_usage", DEFAULT_NAME, "test@example.com")
+    serialized = json.dumps(sensor.extra_state_attributes)
+    assert len(serialized) < SAFETY_BUDGET, (
+        f"gas_monthly_usage attributes are {len(serialized)} bytes; "
+        f"safety budget is {SAFETY_BUDGET}"
+    )


### PR DESCRIPTION
## Summary

A new Lovelace card mirroring the monthly mode of the existing electricity `energy-usage-card.js`, but specialized for gas:

- Bar chart with prev/next month nav (~6 periods per page)
- **Yellow** bars `rgb(255, 240, 0)` for actual meter reads
- **Gray** bars `#727272` for Mercury estimates
- Click any bar → invoice range, `\$cost`, `kWh`, `(estimated)` annotation when applicable
- Legend with both "Actual" and "Estimated" indicators

Closes the data-path gap on `main` where `gas_monthly_usage_history` existed in `coordinator.data` (post-v1.5.2 via pymercury 1.1.3 `consumption_periods`) but was not exposed on any sensor entity, so frontend cards had no way to read it.

## How it looks (described)

```
┌──────────────────────────────────────────────┐
│ Gas Monthly Usage                            │
│  <  27 Feb 2026 - 27 Mar 2026  >             │
│  ┌──────────────────────────────────┐        │
│  │  ░ ▓ ░ ▓ ░ ░ ▓ ░ ▓ ░             │        │
│  │ Jul Jul Aug Sep Oct Nov Dec...   │        │
│  │ est act est act est est act ...  │        │
│  └──────────────────────────────────┘        │
│  ● Actual  ○ Estimated                       │
│  Your gas usage for this billing period      │
│  $156.28 | 460.00 kWh                        │
└──────────────────────────────────────────────┘
```

## Two-pass implementation

**Pass 1**: followed `.claude/PRPs/plans/gas-monthly-summary-card.plan.md` (the 7 atomic tasks + a README addition).

**Pass 2**: ran `code-reviewer` + `simplifier` agents in parallel and applied 5 refinements:

| Issue | Fix |
|---|---|
| Gas attribute block was nested INSIDE `CHART_DATA_SENSORS` block — gas sensor inherited all electricity history attrs (Issue #4 budget risk) | Moved gas block to be a SIBLING of (not inside) the `CHART_DATA_SENSORS` block; removed `gas_monthly_usage` from the list |
| `chartRawData` could be `undefined` when `onClick` fires before chart creation | Initialized `this.chartRawData = { usage: [] }` in constructor |
| `_hasChartData()` returned truthy for `[]` → half-rendered card with no bars | Now requires `Array.isArray(history) && history.length > 0` |
| `_handleNavigation('prev')` could push `_currentPage` past `maxPage` on single-page datasets | Added `maxPage > 0` boundary guard |
| Chart-data derivation duplicated in `_createOrUpdateChart` and `_updateChartData`; date-range formatting duplicated in two branches; unreachable camelCase fallback | Extracted `_buildChartView` and `_formatInvoiceRange` helpers; dropped dead code |

## Files changed

- `custom_components/mercury_co_nz/const.py` — `gas_monthly_usage` SENSOR_TYPES entry + JSMODULES entry
- `custom_components/mercury_co_nz/sensor.py` — gas attribute block as sibling to electricity CHART_DATA_SENSORS block (Issue #4 isolation)
- `custom_components/mercury_co_nz/__init__.py` — `gas-monthly-summary-card.js` in `ALLOWED_JS_FILES`
- `custom_components/mercury_co_nz/gas-monthly-summary-card.js` (NEW, ~530 LOC) — the LitElement card
- `custom_components/mercury_co_nz/styles.js` — `.legend-circle.estimated` modifier in shared `chartLegendStyles`
- `custom_components/mercury_co_nz/manifest.json` — `1.5.2` → `1.6.0`
- `custom_components/mercury_co_nz/tests/test_attributes.py` — +4 tests
- `README.md` — Demo + Usage Examples + corrected v1.4.0-era "no live gas sensor entity" caveat

## Tests

107 pass (+4 new):
- `test_gas_monthly_usage_sensor_exposes_chart_history` — sensor populates `gas_monthly_usage_history`
- `test_gas_monthly_usage_native_value_reads_total` — `state` reads the kWh scalar
- `test_electricity_sensors_do_not_get_gas_attributes` — Issue #4 isolation guard
- `test_gas_sensor_stays_under_safety_budget` — full-year fixture (12 periods) under 14KB cap

## Migration note for users

After updating to v1.6.0, **fully restart Home Assistant** (Settings → System → Restart) — HACS does not hot-swap Python modules, so the new `sensor.mercury_nz_gas_monthly_usage` entity and JS card only load after a process restart. Then add the card via the dashboard editor:

```yaml
type: custom:mercury-gas-monthly-summary-card
entity: sensor.mercury_nz_gas_monthly_usage
name: Gas Monthly Usage
```

## Test plan

- [ ] Test HA instance with a gas service shows the new entity in Developer Tools → States
- [ ] Entity attributes include `gas_monthly_usage_history`, `gas_monthly_data_points`, `gas_monthly_total_usage`, `gas_monthly_total_cost`
- [ ] Lovelace card-picker shows "Mercury Gas Monthly Summary Card"
- [ ] Card renders bar chart with correct kWh values per billing period
- [ ] Yellow bars match `is_estimated: false` periods; gray bars match `is_estimated: true`
- [ ] Prev/next nav pages back through history; arrows hide at boundaries
- [ ] Click a bar → info panel shows invoice range + cost + kWh; estimated periods get an `(estimated)` annotation
- [ ] No regression on existing electricity sensor attribute size (Issue #4 still passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)