### PR TITLE
fix: v1.6.3 — restore stacked info-panel layout

### DIFF
--- a/custom_components/mercury_co_nz/gas-monthly-summary-card.js
+++ b/custom_components/mercury_co_nz/gas-monthly-summary-card.js
@@ -23,21 +23,8 @@ class MercuryGasMonthlySummaryCard extends LitElement {
         color: white;
       }
 
-      /* Single-row layout: "🔥 Your gas usage for this billing period   $X.XX | XXX kWh"
-         falls back to wrapped on narrow screens. */
-      .usage-details {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: baseline;
-        gap: 16px;
-      }
-      .usage-date {
-        margin-bottom: 0;
-      }
-      .usage-stats {
-        font-weight: 600;
-      }
-
+      /* Description on line 1 (with 🔥 prefix), $X.XX | XXX kWh on line 2 —
+         restoring the v1.6.0 stacked layout per user feedback in v1.6.3. */
       .fire-emoji {
         margin-right: 6px;
         font-size: 16px;
@@ -553,7 +540,7 @@ if (window.customCards) {
 }
 
 console.info(
-  '%c MERCURY-GAS-MONTHLY-SUMMARY-CARD %c v1.6.2 ',
+  '%c MERCURY-GAS-MONTHLY-SUMMARY-CARD %c v1.6.3 ',
   'color: orange; font-weight: bold; background: black',
   'color: white; font-weight: bold; background: dimgray'
 );

--- a/custom_components/mercury_co_nz/manifest.json
+++ b/custom_components/mercury_co_nz/manifest.json
@@ -10,5 +10,5 @@
   "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.3"],
   "frontend": true,
   "min_ha_version": "2025.11.0",
-  "version": "1.6.2"
+  "version": "1.6.3"
 }


### PR DESCRIPTION
v1.6.2 put the description and \"\$X.XX | XXX kWh\" on the same row via flex layout. User feedback: prefer the original v1.6.0 stacked layout where the cost/kWh sits on a second line below the description, with the 🔥 emoji prefixing only the description line.

## Changes

Reverted only the layout from v1.6.2 — kept the gray-background-on-estimate logic, the Estimate label rename, and the fire-emoji prefix.

`gas-monthly-summary-card.js` `static styles` block:
- Removed `.usage-details { display: flex; ... }` (back to default block stacking)
- Removed `.usage-date { margin-bottom: 0; }` override (lets the shared 4px gap between the two lines reappear)
- Removed `.usage-stats { font-weight: 600; }` override (matches the v1.6.0 visual)

`manifest.json`: 1.6.2 → 1.6.3.
Console banner: bumped to v1.6.3 to match.

## Result

```
🔥 Your gas usage for this billing period
\$156.28 | 460.00 kWh
```

(two lines, with 🔥 prefixing only the first; gray background when an estimate is selected stays from v1.6.2.)

## Tests

110 pass. No new tests — JS card has no test infrastructure in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)