### PR TITLE
feat: v1.6.5 — ⚡ lightning emoji on energy card chart info panel

### DIFF
--- a/custom_components/mercury_co_nz/energy-usage-card.js
+++ b/custom_components/mercury_co_nz/energy-usage-card.js
@@ -9,7 +9,26 @@ class MercuryEnergyUsageCard extends LitElement {
   static styles = [
     mercuryChartStyles,
     css`
-      /* Energy chart specific overrides */
+      /* Two-line layout with ⚡ emoji as a left column:
+           ⚡ Your usage on Tuesday 27 March 2026
+              $4.27 | 13.43 kWh
+         Both text lines start at the same x-offset; the emoji sits to
+         the left, vertically aligned to the top so it tracks the first
+         line. Matches the gas card's 🔥-prefix layout (v1.6.4). */
+      .usage-details {
+        display: flex;
+        align-items: flex-start;
+        gap: 8px;
+      }
+      .lightning-emoji {
+        font-size: 16px;
+        line-height: 1.2;
+        flex-shrink: 0;
+      }
+      .usage-text {
+        flex: 1;
+        min-width: 0;
+      }
     `
   ];
 
@@ -1277,8 +1296,11 @@ class MercuryEnergyUsageCard extends LitElement {
             <div class="data-info">
               ${this._selectedDate ? html`
                 <div class="usage-details">
-                  <div class="usage-date">${this._currentPeriod === 'monthly' ? 'Your usage this billing period' : `Your usage on ${this._selectedDate.dateFormatted}`}</div>
-                  <div class="usage-stats">$${this._selectedDate.cost.toFixed(2)} | ${this._selectedDate.consumption.toFixed(2)} kWh</div>
+                  <span class="lightning-emoji">⚡</span>
+                  <div class="usage-text">
+                    <div class="usage-date">${this._currentPeriod === 'monthly' ? 'Your usage this billing period' : `Your usage on ${this._selectedDate.dateFormatted}`}</div>
+                    <div class="usage-stats">$${this._selectedDate.cost.toFixed(2)} | ${this._selectedDate.consumption.toFixed(2)} kWh</div>
+                  </div>
                 </div>
               ` : html`Loading...`}
             </div>
@@ -1387,7 +1409,7 @@ window.customCards = window.customCards || [];
 }
 
 console.info(
-  '%c MERCURY-ENERGY-USAGE-CARD %c v1.0.0 ',
+  '%c MERCURY-ENERGY-USAGE-CARD %c v1.6.5 ',
   'color: orange; font-weight: bold; background: black',
   'color: white; font-weight: bold; background: dimgray'
 );

--- a/custom_components/mercury_co_nz/manifest.json
+++ b/custom_components/mercury_co_nz/manifest.json
@@ -10,5 +10,5 @@
   "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.3"],
   "frontend": true,
   "min_ha_version": "2025.11.0",
-  "version": "1.6.4"
+  "version": "1.6.5"
 }


### PR DESCRIPTION
Apply the v1.6.4 emoji-as-left-column layout that the gas card has (🔥 fire) to the electricity bar-chart card, using ⚡ to represent energy/electric. Visually consistent across both fuel types.

```
⚡ Your usage on Tuesday 27 March 2026
   \$4.27 | 13.43 kWh
```

(or in monthly mode: \"Your usage this billing period\")

## Changes

- `energy-usage-card.js`: wrap `.usage-date` and `.usage-stats` in a new `.usage-text` div; `<span class=\"lightning-emoji\">⚡</span>` as a sibling inside `.usage-details` (becomes flex with `align-items: flex-start; gap: 8px`). Card-scoped CSS in `static styles` — no edits to shared `styles.js`.
- `manifest.json`: 1.6.4 → 1.6.5.
- Console banner: bumped from stale `v1.0.0` → `v1.6.5`.

No estimate/actual gray-background logic — Mercury electricity API doesn't have the parallel-pair structure gas does, so chart-info stays yellow.

110 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)