### PR TITLE
fix: v1.6.7 — pin mercury-co-nz-api>=1.1.5 (renamed plan charges)

### DIFF
--- a/custom_components/mercury_co_nz/manifest.json
+++ b/custom_components/mercury_co_nz/manifest.json
@@ -7,8 +7,8 @@
   "documentation": "https://github.com/bkintanar/home-assistant-mercury-co-nz",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.4"],
+  "requirements": ["aiohttp>=3.8.0", "mercury-co-nz-api>=1.1.5"],
   "frontend": true,
   "min_ha_version": "2025.11.0",
-  "version": "1.6.6"
+  "version": "1.6.7"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 # These are automatically installed by Home Assistant from manifest.json
 
 aiohttp>=3.8.0
-mercury-co-nz-api>=1.1.4
+mercury-co-nz-api>=1.1.5

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ homeassistant>=2025.11.0
 # Core dependencies
 aiohttp>=3.8.0
 voluptuous>=0.13.0
-mercury-co-nz-api>=1.1.4
+mercury-co-nz-api>=1.1.5
 
 # Development tools
 black>=22.0.0


### PR DESCRIPTION
## Summary

Pins `mercury-co-nz-api>=1.1.5`, which fixes plan-rate parsing after Mercury renamed the charge/rate names (`"Daily Fixed Charge"` → `"Fixed Daily Charge"`, `"Anytime"` → `"Inclusive"`). Without 1.1.5, `daily_fixed_charge` / `current_rate` sensors return `None`/`unavailable` on affected accounts.

Fixes are upstream in pymercury (bkintanar/pymercury#11, released as 1.1.5). **No integration code change** — the integration already reads `daily_fixed_charge` / `anytime_rate`; 1.1.5 just makes them non-`None` again.

## Why bump the pin (not just rely on `>=1.1.4`)?

`>=1.1.4` already permits 1.1.5, but HA only re-resolves a cached dependency when the requirement **string changes**. Existing installs have 1.1.4 cached (satisfies `>=1.1.4`) and would never upgrade. Bumping to `>=1.1.5` forces the re-resolve on update — same rationale as v1.5.1.

## Changes

| File | Change |
|------|--------|
| `manifest.json` | pin `mercury-co-nz-api>=1.1.5`; version `1.6.6` → `1.6.7` |
| `requirements.txt`, `requirements_dev.txt` | pin `>=1.1.5` |

## Testing

- [x] `pytest custom_components/mercury_co_nz/tests/` — **110 passed** against pymercury 1.1.5

## Notes

- After merge, cut a GitHub Release **v1.6.7** so HACS surfaces the update.
- Users on the renamed plan can remove any local workaround once on 1.6.7.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
